### PR TITLE
Add scrollable layouts and style preview

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -40,6 +42,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -49,6 +52,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -61,6 +65,7 @@ import com.example.kokoro82m.utils.playAudio
 import com.example.kokoro82m.utils.saveAudio
 import com.example.kokoro82m.utils.SettingsManager
 import com.example.kokoro82m.utils.DebugLogger
+import com.example.kokoro82m.ui.responsiveTextSize
 import com.google.android.material.color.DynamicColors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -282,10 +287,12 @@ fun BasicScreen(
     )
     var expanded by remember { mutableStateOf(false) }
 
+    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .padding(16.dp)
-            .fillMaxSize(),
+            .fillMaxSize()
+            .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         TextField(
@@ -338,7 +345,10 @@ fun BasicScreen(
             }
         }
 
-        Text("Speed: $speed")
+        Text(
+            text = "Speed: $speed",
+            style = TextStyle(fontSize = responsiveTextSize(16.sp))
+        )
         Slider(
             value = speed,
             onValueChange = {

--- a/app/src/main/java/com/example/kokoro82m/screens/AboutScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/AboutScreen.kt
@@ -8,6 +8,8 @@ import android.net.Uri
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -29,10 +31,12 @@ import androidx.compose.ui.unit.sp
 fun Acknowledgements() {
     val context = LocalContext.current
 
+    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .padding(16.dp)
             .fillMaxWidth()
+            .verticalScroll(scrollState)
     ) {
         Text(
             text = "Thank You for Making This Happen!",

--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -15,12 +15,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
@@ -98,61 +96,72 @@ fun BookScreen(
         }
     }
 
-    val scrollState = rememberScrollState()
-    Column(
+    val listState = rememberLazyListState()
+    LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp)
-            .verticalScroll(scrollState),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        state = listState
     ) {
-        StyleSelector(
-            styleNames = styleLoader.names,
-            selectedStyles = selectedStyles,
-            onAddStyle = { style ->
-                selectedStyles = selectedStyles + style
-                weights = weights + (style to 1f)
-            },
+        item {
+            StyleSelector(
+                styleNames = styleLoader.names,
+                selectedStyles = selectedStyles,
+                onAddStyle = { style ->
+                    selectedStyles = selectedStyles + style
+                    weights = weights + (style to 1f)
+                },
             onRemoveStyle = { style ->
                 selectedStyles = selectedStyles - style
                 weights = weights - style
             }
         )
 
-        WeightSliders(
-            selectedStyles = selectedStyles,
-            weights = weights,
-            onWeightChanged = { style, value ->
-                weights = weights.toMutableMap().apply { put(style, value) }
-            }
-        )
+        }
+        item {
+            WeightSliders(
+                selectedStyles = selectedStyles,
+                weights = weights,
+                onWeightChanged = { style, value ->
+                    weights = weights.toMutableMap().apply { put(style, value) }
+                }
+            )
+        }
 
-        InterpolationModeSelector(
-            currentMode = interpolationMode,
-            onModeSelected = { interpolationMode = it }
-        )
+        item {
+            InterpolationModeSelector(
+                currentMode = interpolationMode,
+                onModeSelected = { interpolationMode = it }
+            )
+        }
 
-        Text(
-            text = "Speed: $speed",
-            style = TextStyle(fontSize = responsiveTextSize(16.sp))
-        )
-        Slider(
-            value = speed,
-            onValueChange = {
-                speed = it
-                SettingsManager.setSpeed(context, it)
-            },
-            valueRange = 0.5f..2.0f,
-            steps = 5,
-            modifier = Modifier.fillMaxWidth()
-        )
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Button(onClick = { launcher.launch(arrayOf("text/plain")) }) {
-                Text("Open File")
-            }
+        item {
+            Text(
+                text = "Speed: $speed",
+                style = TextStyle(fontSize = responsiveTextSize(16.sp))
+            )
+        }
+        item {
+            Slider(
+                value = speed,
+                onValueChange = {
+                    speed = it
+                    SettingsManager.setSpeed(context, it)
+                },
+                valueRange = 0.5f..2.0f,
+                steps = 5,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Button(onClick = { launcher.launch(arrayOf("text/plain")) }) {
+                    Text("Open File")
+                }
             Button(
                 onClick = {
                     if (isPlaying) {
@@ -223,30 +232,33 @@ fun BookScreen(
                 Text("Save")
             }
         }
+        }
 
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
-            itemsIndexed(lines) { index, line ->
+        itemsIndexed(lines) { index, line ->
+            Text(
+                text = line,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(if (index == currentLine) Color.Yellow else Color.Transparent)
+                    .padding(4.dp)
+            )
+        }
+
+        item {
+            debugMessage?.let {
                 Text(
-                    text = line,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(if (index == currentLine) Color.Yellow else Color.Transparent)
-                        .padding(4.dp)
+                    text = it,
+                    color = Color.Red,
+                    modifier = Modifier.padding(top = 8.dp)
                 )
             }
         }
 
-        debugMessage?.let {
-            Text(
-                text = it,
-                color = Color.Red,
-                modifier = Modifier.padding(top = 8.dp)
-            )
-        }
-
-        if (SettingsManager.isDebug(context)) {
-            val logs = DebugLogger.getLogs().joinToString("\n")
-            Text(logs, modifier = Modifier.padding(top = 8.dp))
+        item {
+            if (SettingsManager.isDebug(context)) {
+                val logs = DebugLogger.getLogs().joinToString("\n")
+                Text(logs, modifier = Modifier.padding(top = 8.dp))
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState

--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -46,7 +48,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.Alignment
 import com.example.kokoro82m.utils.AudioPlayer
 import com.example.kokoro82m.utils.InterpolationMode
@@ -57,6 +61,7 @@ import com.example.kokoro82m.utils.mixStyles
 import com.example.kokoro82m.utils.saveAudio
 import com.example.kokoro82m.utils.SettingsManager
 import com.example.kokoro82m.utils.DebugLogger
+import com.example.kokoro82m.ui.responsiveTextSize
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -93,10 +98,12 @@ fun BookScreen(
         }
     }
 
+    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
+            .padding(16.dp)
+            .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         StyleSelector(
@@ -125,7 +132,10 @@ fun BookScreen(
             onModeSelected = { interpolationMode = it }
         )
 
-        Text("Speed: $speed")
+        Text(
+            text = "Speed: $speed",
+            style = TextStyle(fontSize = responsiveTextSize(16.sp))
+        )
         Slider(
             value = speed,
             onValueChange = {

--- a/app/src/main/java/com/example/kokoro82m/screens/CreationsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/CreationsScreen.kt
@@ -1,15 +1,12 @@
 package com.example.kokoro82m.screens
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,16 +35,15 @@ fun CreationsScreen() {
         creations = withContext(Dispatchers.IO) { loadCreations(context) }
     }
 
-    val scrollState = rememberScrollState()
-    Column(
+    val listState = rememberLazyListState()
+    LazyColumn(
         modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp)
-            .verticalScroll(scrollState),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        state = listState
     ) {
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
-            items(creations) { creation ->
+        items(creations) { creation ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/example/kokoro82m/screens/CreationsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/CreationsScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -36,10 +38,12 @@ fun CreationsScreen() {
         creations = withContext(Dispatchers.IO) { loadCreations(context) }
     }
 
+    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
+            .padding(16.dp)
+            .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         LazyColumn(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/example/kokoro82m/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/MixerScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -37,7 +39,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.example.kokoro82m.utils.InterpolationMode
 import com.example.kokoro82m.utils.PhonemeConverter
 import com.example.kokoro82m.utils.StyleLoader
@@ -47,6 +51,7 @@ import com.example.kokoro82m.utils.playAudio
 import com.example.kokoro82m.utils.saveAudio
 import com.example.kokoro82m.utils.SettingsManager
 import com.example.kokoro82m.utils.DebugLogger
+import com.example.kokoro82m.ui.responsiveTextSize
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -78,10 +83,12 @@ fun MixerScreen(
     var weights by remember { mutableStateOf(initial.second) }
     var interpolationMode by remember { mutableStateOf(initial.third) }
 
+    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .padding(16.dp)
-            .fillMaxSize(),
+            .fillMaxSize()
+            .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         TextField(
@@ -93,7 +100,10 @@ fun MixerScreen(
             modifier = Modifier.fillMaxWidth()
         )
 
-        Text("Speed: $speed")
+        Text(
+            text = "Speed: $speed",
+            style = TextStyle(fontSize = responsiveTextSize(16.sp))
+        )
         Slider(
             value = speed,
             onValueChange = {
@@ -137,7 +147,10 @@ fun MixerScreen(
             }
         )
 
-        Row(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
             Button(
                 onClick = {
                     shouldSaveFile = false
@@ -152,6 +165,30 @@ fun MixerScreen(
                 modifier = Modifier.weight(1f),
                 enabled = !isProcessing
             ) { Text(if (isProcessing) "Mixing..." else "Play") }
+
+            Button(
+                onClick = {
+                    shouldSaveFile = false
+                    isProcessing = true
+                    scope.launch {
+                        val mixed = mixStyles(styleLoader, selectedStyles, weights, interpolationMode)
+                        generateAudio(
+                            "This is a style preview",
+                            mixed,
+                            speed,
+                            shouldSaveFile,
+                            session,
+                            phonemeConverter,
+                            scope,
+                            context
+                        ) {
+                            isProcessing = false
+                        }
+                    }
+                },
+                modifier = Modifier.weight(1f),
+                enabled = !isProcessing
+            ) { Text(if (isProcessing) "Mixing..." else "Preview") }
 
             Button(
                 onClick = {

--- a/app/src/main/java/com/example/kokoro82m/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/SettingsScreen.kt
@@ -14,6 +14,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.sp
+import com.example.kokoro82m.ui.responsiveTextSize
 import com.example.kokoro82m.utils.SettingsManager
 
 @Composable
@@ -21,7 +26,12 @@ fun SettingsScreen() {
     val context = LocalContext.current
     var debug by remember { mutableStateOf(SettingsManager.isDebug(context)) }
 
-    Column(modifier = Modifier.padding(16.dp)) {
+    val scrollState = rememberScrollState()
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .verticalScroll(scrollState)
+    ) {
         androidx.compose.foundation.layout.Row(verticalAlignment = Alignment.CenterVertically) {
             Switch(
                 checked = debug,
@@ -30,7 +40,11 @@ fun SettingsScreen() {
                     SettingsManager.setDebug(context, it)
                 }
             )
-            Text(text = "Debug Mode", modifier = Modifier.padding(start = 8.dp))
+            Text(
+                text = "Debug Mode",
+                modifier = Modifier.padding(start = 8.dp),
+                style = TextStyle(fontSize = responsiveTextSize(16.sp))
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/ui/Responsive.kt
+++ b/app/src/main/java/com/example/kokoro82m/ui/Responsive.kt
@@ -1,0 +1,17 @@
+package com.example.kokoro82m.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+
+/**
+ * Returns a text size scaled to the current screen width.
+ * A baseline width of 360dp is used for scaling.
+ */
+@Composable
+fun responsiveTextSize(baseSize: TextUnit): TextUnit {
+    val configuration = LocalConfiguration.current
+    val scale = configuration.screenWidthDp / 360f
+    return (baseSize.value * scale).sp
+}


### PR DESCRIPTION
## Summary
- add a `responsiveTextSize` helper to scale fonts
- make all screens vertically scrollable
- preview mixed styles directly on the mixer screen

## Testing
- `gradle test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601b9f2b4c8331b62fb1492ba92fe9