### PR TITLE
Add Tokenizer tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,8 @@ dependencies {
     implementation(libs.material)
     implementation("androidx.compose.material:material-icons-extended:1.6.8")
     testImplementation(libs.junit)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.inline)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/test/java/com/example/kokoro82m/AudioPlayerSimpleTest.kt
+++ b/app/src/test/java/com/example/kokoro82m/AudioPlayerSimpleTest.kt
@@ -1,0 +1,58 @@
+import com.example.kokoro82m.utils.AudioPlayer
+import com.example.kokoro82m.utils.PlayerState
+import android.media.AudioTrack
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import android.media.AudioFormat
+class AudioPlayerSimpleTest {
+    lateinit var player: AudioPlayer
+    @Before
+    fun setup() {
+        player = AudioPlayer(CoroutineScope(Dispatchers.Unconfined)) {}
+        val field = AudioPlayer::class.java.getDeclaredField("audioTrack")
+        field.isAccessible = true
+        field.set(player, null)
+        val logField = Class.forName("com.example.kokoro82m.utils.DebugLogger").getDeclaredField("logFile")
+        logField.isAccessible = true
+        logField.set(null, java.io.File.createTempFile("log", ".txt"))
+        val pcmField = AudioPlayer::class.java.getDeclaredField("pcmData")
+        pcmField.isAccessible = true
+        pcmField.set(player, ByteArray(0))
+    }
+
+    @Test
+    fun pauseFromPlaying() {
+        val stateField = AudioPlayer::class.java.getDeclaredField("currentState")
+        stateField.isAccessible = true
+        stateField.set(player, PlayerState.PLAYING)
+
+        player.pause()
+
+        assertEquals(PlayerState.PAUSED, stateField.get(player))
+    }
+
+    @Test
+    fun playResumesFromPaused() {
+        val stateField = AudioPlayer::class.java.getDeclaredField("currentState")
+        stateField.isAccessible = true
+        stateField.set(player, PlayerState.PAUSED)
+
+        player.play()
+
+        assertEquals(PlayerState.PLAYING, stateField.get(player))
+    }
+
+    @Test
+    fun stopReleasesResources() {
+        val stateField = AudioPlayer::class.java.getDeclaredField("currentState")
+        stateField.isAccessible = true
+        stateField.set(player, PlayerState.PLAYING)
+
+        player.stop()
+
+        assertEquals(PlayerState.IDLE, stateField.get(player))
+    }
+}

--- a/app/src/test/java/com/example/kokoro82m/BookmarkManagerTest.kt
+++ b/app/src/test/java/com/example/kokoro82m/BookmarkManagerTest.kt
@@ -1,0 +1,27 @@
+import android.content.Context
+import com.example.kokoro82m.utils.BookmarkManager
+import com.example.kokoro82m.utils.DatabaseManager
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+
+class BookmarkManagerTest {
+    private val context = mock(Context::class.java)
+
+    @Test
+    fun saveLoadAndClearBookmark() {
+        val uri = "sample"
+        mockStatic(DatabaseManager::class.java).use { db ->
+            db.`when`<Int?> { DatabaseManager.getBookmark(context, uri) }.thenReturn(5)
+            BookmarkManager.save(context, uri, 5)
+            db.verify { DatabaseManager.setBookmark(context, uri, 5) }
+            assertEquals(5, BookmarkManager.load(context, uri))
+
+            db.`when`<Int?> { DatabaseManager.getBookmark(context, uri) }.thenReturn(null)
+            BookmarkManager.clear(context, uri)
+            db.verify { DatabaseManager.clearBookmark(context, uri) }
+            assertEquals(-1, BookmarkManager.load(context, uri))
+        }
+    }
+}

--- a/app/src/test/java/com/example/kokoro82m/TokenizerTest.kt
+++ b/app/src/test/java/com/example/kokoro82m/TokenizerTest.kt
@@ -1,0 +1,35 @@
+package com.example.kokoro82m
+
+import com.example.kokoro82m.utils.Tokenizer
+import org.junit.Test
+import org.junit.Assert.*
+
+class TokenizerTest {
+    @Test
+    fun tokenizeValidCharacters() {
+        val text = "AB?"
+        val tokens = Tokenizer.tokenize(text)
+        assertEquals(text.length, tokens.size)
+    }
+
+    @Test
+    fun tokenizeUnknownSymbolThrows() {
+        try {
+            Tokenizer.tokenize("\u2603")
+            fail("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun tokenizeLongTextThrows() {
+        val longText = "A".repeat(513)
+        try {
+            Tokenizer.tokenize(longText)
+            fail("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.04.01"
 material = "1.12.0"
+mockito = "5.2.0"
+mockitoInline = "5.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,6 +29,8 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 material3 = { module = "androidx.compose.material3:material3" }
+mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
+mockito-inline = { group = "org.mockito", name = "mockito-inline", version.ref = "mockitoInline" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add unit tests for `Tokenizer` utility

## Testing
- `./gradlew test --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_687acd315fdc8331a44abdbb6a4943df