### PR TITLE
Improve audio file naming

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -156,7 +156,7 @@ private fun generateAudio(
             )
 
             if (shouldSave) {
-                saveAudio(audioData, context)
+                saveAudio(audioData, context, style)
             }
         } catch (e: Exception) {
             DebugLogger.log("Error: ${e.message}")

--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -26,6 +26,7 @@ import com.example.kokoro82m.viewmodel.BookViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -56,6 +57,7 @@ fun BookScreen(
     var interpolationMode by remember { mutableStateOf(InterpolationMode.LINEAR) }
     var speed by remember { mutableFloatStateOf(SettingsManager.getSpeed(context)) }
     var debugMessage by remember { mutableStateOf<String?>(null) }
+    var isProcessing by remember { mutableStateOf(false) }
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
@@ -170,32 +172,28 @@ fun BookScreen(
                     onClick = {
                         if (playerState == PlayerState.PLAYING) {
                             bookViewModel.audioPlayer.pause()
-                            playJob?.cancel()
                         } else {
-                            if (playerState == PlayerState.PAUSED) {
-                                bookViewModel.audioPlayer.play()
-                            } else {
-                                playJob = playBook(
-                                    scope = scope,
-                                    session = session,
-                                    phonemeConverter = phonemeConverter,
-                                    styleLoader = styleLoader,
-                                    selectedStyles = selectedStyles,
-                                    weights = weights,
-                                    mode = interpolationMode,
-                                    speed = speed,
-                                    lines = lines,
-                                    startLine = currentLine.coerceAtLeast(0),
-                                    bookUri = bookUri,
-                                    audioPlayer = bookViewModel.audioPlayer,
-                                    context = context,
-                                    onLineChanged = { bookViewModel.setCurrentLine(it) },
-                                    onFinished = {
-                                        bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
-                                        bookmarkLine = -1
-                                    }
-                                )
-                            }
+                            playJob?.cancel()
+                            playJob = playBook(
+                                scope = scope,
+                                session = session,
+                                phonemeConverter = phonemeConverter,
+                                styleLoader = styleLoader,
+                                selectedStyles = selectedStyles,
+                                weights = weights,
+                                mode = interpolationMode,
+                                speed = speed,
+                                lines = lines,
+                                startLine = currentLine.coerceAtLeast(0),
+                                bookUri = bookUri,
+                                audioPlayer = bookViewModel.audioPlayer,
+                                context = context,
+                                onLineChanged = { bookViewModel.setCurrentLine(it) },
+                                onFinished = {
+                                    bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
+                                    bookmarkLine = -1
+                                }
+                            )
                         }
                     },
                     enabled = lines.isNotEmpty(),
@@ -221,6 +219,7 @@ fun BookScreen(
                 }
                 Button(
                     onClick = {
+                        isProcessing = true
                         scope.launch(Dispatchers.IO) {
                             try {
                                 debugMessage = null
@@ -247,13 +246,17 @@ fun BookScreen(
                                 withContext(Dispatchers.Main) {
                                     debugMessage = e.localizedMessage
                                 }
+                            } finally {
+                                withContext(Dispatchers.Main) {
+                                    isProcessing = false
+                                }
                             }
                         }
                     },
-                    enabled = lines.isNotEmpty(),
+                    enabled = lines.isNotEmpty() && !isProcessing,
                     modifier = Modifier.weight(1f)
                 ) {
-                    Text("Save")
+                    Text(if (isProcessing) "Saving..." else "Save")
                 }
             }
         }
@@ -265,6 +268,7 @@ fun BookScreen(
                     .fillMaxWidth()
                     .clickable {
                         bookViewModel.setCurrentLine(index)
+                        playJob?.cancel() // Stop any existing playback
                         playJob = playBook(
                             scope = scope,
                             session = session,
@@ -310,6 +314,29 @@ fun BookScreen(
     }
 }
 
+private suspend fun playAudio(
+    line: String,
+    styleVector: Array<FloatArray>,
+    speed: Float,
+    session: OrtSession,
+    phonemeConverter: PhonemeConverter,
+    audioPlayer: AudioPlayer
+) {
+    try {
+        val phonemes = phonemeConverter.phonemize(line)
+        val (audio, _) = createAudioFromStyleVector(
+            phonemes = phonemes,
+            voice = styleVector,
+            speed = speed,
+            session = session
+        )
+        audioPlayer.prepare(audio)
+        audioPlayer.playBlocking()
+    } catch (e: Exception) {
+        DebugLogger.log("playAudio failed: ${e.localizedMessage}")
+    }
+}
+
 private fun playBook(
     scope: CoroutineScope,
     session: OrtSession,
@@ -337,33 +364,42 @@ private fun playBook(
                 mode = mode
             )
             for (index in startLine until lines.size) {
-                if (audioPlayer.getState() == PlayerState.IDLE) {
+                if (!isActive) {
                     completed = false
                     break
                 }
+
                 withContext(Dispatchers.Main) {
                     onLineChanged(index)
                 }
                 bookUri?.let { BookmarkManager.save(context, it.toString(), index) }
                 val line = lines[index]
-                val phonemes = phonemeConverter.phonemize(line)
-                val (audio, _) = createAudioFromStyleVector(
-                    phonemes = phonemes,
-                    voice = mixedVector,
+
+                playAudio(
+                    line = line,
+                    styleVector = mixedVector,
                     speed = speed,
-                    session = session
+                    session = session,
+                    phonemeConverter = phonemeConverter,
+                    audioPlayer = audioPlayer
                 )
-                audioPlayer.prepare(audio)
-                audioPlayer.playBlocking()
+
+                if (audioPlayer.getState() == PlayerState.PAUSED) {
+                    completed = false
+                    break
+                }
             }
         } catch (e: Exception) {
             completed = false
             DebugLogger.log("playBook failed: ${e.localizedMessage}")
         } finally {
             withContext(Dispatchers.Main) {
-                onLineChanged(-1)
-                if (completed) {
-                    onFinished()
+                if (audioPlayer.getState() != PlayerState.PAUSED) {
+                    onLineChanged(-1)
+                    if (completed) {
+                        onFinished()
+                    }
+                    audioPlayer.stop()
                 }
             }
         }

--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -45,7 +45,7 @@ fun BookScreen(
     val playerState by bookViewModel.playerState.collectAsState()
 
     val bookUri by bookViewModel.bookUri.collectAsState()
-    var bookmarkLine by remember { mutableIntStateOf(-1) }
+    var bookmark by remember { mutableStateOf<Bookmark?>(null) }
 
     var playJob by remember { mutableStateOf<Job?>(null) }
 
@@ -69,10 +69,11 @@ fun BookScreen(
 
     LaunchedEffect(bookUri) {
         bookUri?.let {
-            bookmarkLine = BookmarkManager.load(context, it.toString())
-            if (bookmarkLine != -1) {
-                bookViewModel.setCurrentLine(bookmarkLine)
-            } else {
+            bookmark = BookmarkManager.load(context, it.toString())
+            DebugLogger.log("Loaded bookmark: $bookmark")
+            bookmark?.let {
+                bookViewModel.setCurrentLine(it.line)
+            } ?: run {
                 bookViewModel.setCurrentLine(0)
             }
         }
@@ -140,19 +141,19 @@ fun BookScreen(
             )
         }
 
-        if (bookmarkLine >= 0 && playerState == PlayerState.IDLE) {
+        if (bookmark != null && playerState == PlayerState.IDLE) {
             item {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    Text("Resume at line ${bookmarkLine + 1}")
-                    Button(onClick = { bookViewModel.setCurrentLine(bookmarkLine) }) {
+                    Text("Resume at line ${bookmark!!.line + 1}")
+                    Button(onClick = { bookViewModel.setCurrentLine(bookmark!!.line) }) {
                         Text("Go")
                     }
                     Button(onClick = {
                         bookUri?.let { BookmarkManager.clear(context, it.toString()) }
-                        bookmarkLine = -1
+                        bookmark = null
                         bookViewModel.setCurrentLine(-1)
                     }) {
                         Text("Clear")
@@ -172,6 +173,11 @@ fun BookScreen(
                     onClick = {
                         if (playerState == PlayerState.PLAYING) {
                             bookViewModel.audioPlayer.pause()
+                            bookUri?.let {
+                                val position = bookViewModel.audioPlayer.getPosition()
+                                DebugLogger.log("Saving bookmark at line $currentLine, position $position")
+                                BookmarkManager.save(context, it.toString(), currentLine, position)
+                            }
                         } else {
                             playJob?.cancel()
                             playJob = playBook(
@@ -191,8 +197,9 @@ fun BookScreen(
                                 onLineChanged = { bookViewModel.setCurrentLine(it) },
                                 onFinished = {
                                     bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
-                                    bookmarkLine = -1
-                                }
+                                    bookmark = null
+                                },
+                                bookmark = bookmark
                             )
                         }
                     },
@@ -245,7 +252,7 @@ fun BookScreen(
                             } catch (e: Exception) {
                                 withContext(Dispatchers.Main) {
                                     debugMessage = e.localizedMessage
-                                }
+                                 }
                             } finally {
                                 withContext(Dispatchers.Main) {
                                     isProcessing = false
@@ -286,8 +293,9 @@ fun BookScreen(
                             onLineChanged = { bookViewModel.setCurrentLine(it) },
                             onFinished = {
                                 bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
-                                bookmarkLine = -1
-                            }
+                                bookmark = null
+                            },
+                            bookmark = bookmark
                         )
                     }
                     .background(if (index == currentLine) Color.Yellow else Color.Transparent)
@@ -320,9 +328,11 @@ private suspend fun playAudio(
     speed: Float,
     session: OrtSession,
     phonemeConverter: PhonemeConverter,
-    audioPlayer: AudioPlayer
+    audioPlayer: AudioPlayer,
+    position: Int = 0
 ) {
     try {
+        DebugLogger.log("Playing audio for line: '$line' from position $position")
         val phonemes = phonemeConverter.phonemize(line)
         val (audio, _) = createAudioFromStyleVector(
             phonemes = phonemes,
@@ -330,7 +340,7 @@ private suspend fun playAudio(
             speed = speed,
             session = session
         )
-        audioPlayer.prepare(audio)
+        audioPlayer.prepare(audio, position)
         audioPlayer.playBlocking()
     } catch (e: Exception) {
         DebugLogger.log("playAudio failed: ${e.localizedMessage}")
@@ -352,9 +362,11 @@ private fun playBook(
     audioPlayer: AudioPlayer,
     context: Context,
     onLineChanged: (Int) -> Unit,
-    onFinished: () -> Unit
+    onFinished: () -> Unit,
+    bookmark: Bookmark?
 ): Job {
     return scope.launch(Dispatchers.IO) {
+        DebugLogger.log("Starting playbook from line $startLine")
         var completed = true
         try {
             val mixedVector = mixStyles(
@@ -372,8 +384,9 @@ private fun playBook(
                 withContext(Dispatchers.Main) {
                     onLineChanged(index)
                 }
-                bookUri?.let { BookmarkManager.save(context, it.toString(), index) }
                 val line = lines[index]
+                val position = if (index == bookmark?.line) bookmark.position else 0
+                DebugLogger.log("Playing line $index with position $position")
 
                 playAudio(
                     line = line,
@@ -381,7 +394,8 @@ private fun playBook(
                     speed = speed,
                     session = session,
                     phonemeConverter = phonemeConverter,
-                    audioPlayer = audioPlayer
+                    audioPlayer = audioPlayer,
+                    position = position
                 )
 
                 if (audioPlayer.getState() == PlayerState.PAUSED) {

--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.*
@@ -47,6 +48,8 @@ fun BookScreen(
 
     var playJob by remember { mutableStateOf<Job?>(null) }
 
+    val listState = rememberLazyListState()
+
     val styleLoader = remember { StyleLoader(context) }
     var selectedStyles by remember { mutableStateOf(listOf("af_sarah")) }
     var weights by remember { mutableStateOf(mapOf("af_sarah" to 1f)) }
@@ -67,7 +70,15 @@ fun BookScreen(
             bookmarkLine = BookmarkManager.load(context, it.toString())
             if (bookmarkLine != -1) {
                 bookViewModel.setCurrentLine(bookmarkLine)
+            } else {
+                bookViewModel.setCurrentLine(0)
             }
+        }
+    }
+
+    LaunchedEffect(currentLine) {
+        if (currentLine >= 0) {
+            listState.animateScrollToItem(currentLine)
         }
     }
 
@@ -75,7 +86,8 @@ fun BookScreen(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        state = listState
     ) {
         item {
             StyleSelector(
@@ -198,7 +210,10 @@ fun BookScreen(
                     )
                 }
                 Button(
-                    onClick = { bookViewModel.audioPlayer.stop() },
+                    onClick = {
+                        bookViewModel.audioPlayer.stop()
+                        playJob?.cancel()
+                    },
                     enabled = playerState != PlayerState.IDLE,
                     modifier = Modifier.weight(1f)
                 ) {
@@ -226,7 +241,8 @@ fun BookScreen(
                                     )
                                     audioData.addAll(audio.toList())
                                 }
-                                saveAudio(audioData.toFloatArray(), context)
+                                val fileName = buildStyleFileName(selectedStyles, weights, interpolationMode)
+                                saveAudio(audioData.toFloatArray(), context, fileName)
                             } catch (e: Exception) {
                                 withContext(Dispatchers.Main) {
                                     debugMessage = e.localizedMessage
@@ -312,6 +328,7 @@ private fun playBook(
     onFinished: () -> Unit
 ): Job {
     return scope.launch(Dispatchers.IO) {
+        var completed = true
         try {
             val mixedVector = mixStyles(
                 styleLoader = styleLoader,
@@ -320,9 +337,9 @@ private fun playBook(
                 mode = mode
             )
             for (index in startLine until lines.size) {
-                if (!audioPlayer.isPlaying()) {
-                    // This check is tricky now. The loop should be controlled by the player state.
-                    // For now, we assume the loop breaks when stop is called.
+                if (audioPlayer.getState() == PlayerState.IDLE) {
+                    completed = false
+                    break
                 }
                 withContext(Dispatchers.Main) {
                     onLineChanged(index)
@@ -337,14 +354,18 @@ private fun playBook(
                     session = session
                 )
                 audioPlayer.prepare(audio)
-                audioPlayer.play() // This is now a suspend function that waits until done or stopped
-            }
-            withContext(Dispatchers.Main) {
-                onLineChanged(-1)
-                onFinished()
+                audioPlayer.playBlocking()
             }
         } catch (e: Exception) {
+            completed = false
             DebugLogger.log("playBook failed: ${e.localizedMessage}")
+        } finally {
+            withContext(Dispatchers.Main) {
+                onLineChanged(-1)
+                if (completed) {
+                    onFinished()
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/MixerScreen.kt
@@ -49,6 +49,7 @@ import com.example.kokoro82m.utils.playAudio
 import com.example.kokoro82m.utils.saveAudio
 import com.example.kokoro82m.utils.SettingsManager
 import com.example.kokoro82m.utils.DebugLogger
+import com.example.kokoro82m.utils.buildStyleFileName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -148,7 +149,17 @@ fun MixerScreen(
                     isProcessing = true
                     scope.launch {
                         val mixed = mixStyles(styleLoader, selectedStyles, weights, interpolationMode)
-                        generateAudio(text, mixed, speed, shouldSaveFile, session, phonemeConverter, scope, context) {
+                        generateAudio(
+                            text,
+                            mixed,
+                            speed,
+                            shouldSaveFile,
+                            null,
+                            session,
+                            phonemeConverter,
+                            scope,
+                            context
+                        ) {
                             isProcessing = false
                         }
                     }
@@ -163,7 +174,18 @@ fun MixerScreen(
                     isProcessing = true
                     scope.launch {
                         val mixed = mixStyles(styleLoader, selectedStyles, weights, interpolationMode)
-                        generateAudio(text, mixed, speed, shouldSaveFile, session, phonemeConverter, scope, context) {
+                        val fileName = buildStyleFileName(selectedStyles, weights, interpolationMode)
+                        generateAudio(
+                            text,
+                            mixed,
+                            speed,
+                            shouldSaveFile,
+                            fileName,
+                            session,
+                            phonemeConverter,
+                            scope,
+                            context
+                        ) {
                             isProcessing = false
                         }
                     }
@@ -201,6 +223,7 @@ private fun generateAudio(
     style: Array<FloatArray>,
     speed: Float,
     shouldSaveFile: Boolean,
+    fileName: String?,
     session: OrtSession,
     phonemeConverter: PhonemeConverter,
     scope: kotlinx.coroutines.CoroutineScope,
@@ -216,8 +239,8 @@ private fun generateAudio(
                 speed = speed,
                 session = session
             )
-            if (shouldSaveFile) {
-                saveAudio(audio, context)
+            if (shouldSaveFile && fileName != null) {
+                saveAudio(audio, context, fileName)
             }
             playAudio(audio, scope) {}
         } catch (e: Exception) {
@@ -241,6 +264,7 @@ private fun saveStyleConfig(
         .putString("mode", mode.name)
         .apply()
 }
+
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class,
     ExperimentalMaterial3Api::class

--- a/app/src/main/java/com/example/kokoro82m/utils/AudioPlayer.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/AudioPlayer.kt
@@ -74,10 +74,10 @@ class AudioPlayer(
             DebugLogger.log("AudioPlayer start play")
             currentState = PlayerState.PLAYING
             track.play()
-            while (position < data.size && currentState == PlayerState.PLAYING) {
-                val written = track.write(data, position, data.size - position)
-                if (written <= 0) break
-                position += written
+            track.write(data, 0, data.size)
+            // Wait for playback to complete if not paused
+            while (track.playbackHeadPosition < data.size / 2 && currentState == PlayerState.PLAYING) {
+                kotlinx.coroutines.delay(10) // Small delay to prevent busy-waiting
             }
             if (currentState != PlayerState.PAUSED) {
                 stop()
@@ -98,10 +98,10 @@ class AudioPlayer(
             DebugLogger.log("AudioPlayer start play blocking")
             currentState = PlayerState.PLAYING
             track.play()
-            while (position < data.size && currentState == PlayerState.PLAYING && coroutineContext.isActive) {
-                val written = track.write(data, position, data.size - position)
-                if (written <= 0) break
-                position += written
+            track.write(data, 0, data.size)
+            // Wait for playback to complete if not paused
+            while (track.playbackHeadPosition < data.size / 2 && currentState == PlayerState.PLAYING && coroutineContext.isActive) {
+                kotlinx.coroutines.delay(10) // Small delay to prevent busy-waiting
             }
             if (currentState != PlayerState.PAUSED) {
                 stop()

--- a/app/src/main/java/com/example/kokoro82m/utils/AudioPlayer.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/AudioPlayer.kt
@@ -29,8 +29,8 @@ class AudioPlayer(
 
     private val sampleRate = 22050
 
-    fun prepare(audio: FloatArray) {
-        DebugLogger.log("AudioPlayer prepare length=${audio.size}")
+    fun prepare(audio: FloatArray, position: Int = 0) {
+        DebugLogger.log("AudioPlayer prepare length=${audio.size}, position=$position")
         release() // Release any existing track
         val channelConfig = AudioFormat.CHANNEL_OUT_MONO
         val audioFormat = AudioFormat.ENCODING_PCM_16BIT
@@ -58,7 +58,7 @@ class AudioPlayer(
             shortBuffer.put(pcmValue)
         }
         pcmData = byteBuffer.array()
-        position = 0
+        this.position = position
     }
 
     fun play() {
@@ -71,12 +71,12 @@ class AudioPlayer(
         }
 
         scope.launch(Dispatchers.IO) {
-            DebugLogger.log("AudioPlayer start play")
+            DebugLogger.log("AudioPlayer start play from position $position")
             currentState = PlayerState.PLAYING
             track.play()
-            track.write(data, 0, data.size)
+            track.write(data, position, data.size - position)
             // Wait for playback to complete if not paused
-            while (track.playbackHeadPosition < data.size / 2 && currentState == PlayerState.PLAYING) {
+            while (track.playbackHeadPosition < (data.size - position) / 2 && currentState == PlayerState.PLAYING) {
                 kotlinx.coroutines.delay(10) // Small delay to prevent busy-waiting
             }
             if (currentState != PlayerState.PAUSED) {
@@ -95,12 +95,12 @@ class AudioPlayer(
         }
 
         withContext(Dispatchers.IO) {
-            DebugLogger.log("AudioPlayer start play blocking")
+            DebugLogger.log("AudioPlayer start play blocking from position $position")
             currentState = PlayerState.PLAYING
             track.play()
-            track.write(data, 0, data.size)
+            track.write(data, position, data.size - position)
             // Wait for playback to complete if not paused
-            while (track.playbackHeadPosition < data.size / 2 && currentState == PlayerState.PLAYING && coroutineContext.isActive) {
+            while (track.playbackHeadPosition < (data.size - position) / 2 && currentState == PlayerState.PLAYING && coroutineContext.isActive) {
                 kotlinx.coroutines.delay(10) // Small delay to prevent busy-waiting
             }
             if (currentState != PlayerState.PAUSED) {
@@ -111,17 +111,18 @@ class AudioPlayer(
 
     fun pause() {
         if (currentState == PlayerState.PLAYING) {
+            position += audioTrack?.playbackHeadPosition ?: 0
             audioTrack?.pause()
             currentState = PlayerState.PAUSED
-            DebugLogger.log("AudioPlayer pause")
+            DebugLogger.log("AudioPlayer pause at $position")
         }
     }
 
     private fun resume() {
         if (currentState == PlayerState.PAUSED) {
+            DebugLogger.log("AudioPlayer resume from $position")
             audioTrack?.play()
             currentState = PlayerState.PLAYING
-            DebugLogger.log("AudioPlayer resume")
         }
     }
 
@@ -144,4 +145,11 @@ class AudioPlayer(
     fun isPlaying(): Boolean = currentState == PlayerState.PLAYING
 
     fun getState(): PlayerState = currentState
+
+    fun getPosition(): Int {
+        if (currentState == PlayerState.PLAYING) {
+            return position + (audioTrack?.playbackHeadPosition ?: 0)
+        }
+        return position
+    }
 }

--- a/app/src/main/java/com/example/kokoro82m/utils/AudioPlayer.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/AudioPlayer.kt
@@ -8,6 +8,9 @@ import com.example.kokoro82m.utils.DebugLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.isActive
+import kotlin.coroutines.coroutineContext
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -82,6 +85,30 @@ class AudioPlayer(
         }
     }
 
+    suspend fun playBlocking() {
+        val track = audioTrack ?: return
+        val data = pcmData ?: return
+
+        if (currentState == PlayerState.PAUSED) {
+            resume()
+            return
+        }
+
+        withContext(Dispatchers.IO) {
+            DebugLogger.log("AudioPlayer start play blocking")
+            currentState = PlayerState.PLAYING
+            track.play()
+            while (position < data.size && currentState == PlayerState.PLAYING && coroutineContext.isActive) {
+                val written = track.write(data, position, data.size - position)
+                if (written <= 0) break
+                position += written
+            }
+            if (currentState != PlayerState.PAUSED) {
+                stop()
+            }
+        }
+    }
+
     fun pause() {
         if (currentState == PlayerState.PLAYING) {
             audioTrack?.pause()
@@ -115,4 +142,6 @@ class AudioPlayer(
     }
 
     fun isPlaying(): Boolean = currentState == PlayerState.PLAYING
+
+    fun getState(): PlayerState = currentState
 }

--- a/app/src/main/java/com/example/kokoro82m/utils/Bookmark.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/Bookmark.kt
@@ -1,0 +1,3 @@
+package com.example.kokoro82m.utils
+
+data class Bookmark(val line: Int, val position: Int)

--- a/app/src/main/java/com/example/kokoro82m/utils/BookmarkManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/BookmarkManager.kt
@@ -3,12 +3,12 @@ package com.example.kokoro82m.utils
 import android.content.Context
 
 object BookmarkManager {
-    fun save(context: Context, uri: String, line: Int) {
-        DatabaseManager.setBookmark(context, uri, line)
+    fun save(context: Context, uri: String, line: Int, position: Int) {
+        DatabaseManager.setBookmark(context, uri, line, position)
     }
 
-    fun load(context: Context, uri: String): Int {
-        return DatabaseManager.getBookmark(context, uri) ?: -1
+    fun load(context: Context, uri: String): Bookmark? {
+        return DatabaseManager.getBookmark(context, uri)
     }
 
     fun clear(context: Context, uri: String) {

--- a/app/src/main/java/com/example/kokoro82m/utils/DatabaseHelper.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/DatabaseHelper.kt
@@ -10,20 +10,19 @@ class DatabaseHelper private constructor(context: Context) :
 
     override fun onCreate(db: SQLiteDatabase) {
         db.execSQL("CREATE TABLE IF NOT EXISTS settings(key TEXT PRIMARY KEY, value TEXT)")
-        db.execSQL("CREATE TABLE IF NOT EXISTS bookmarks(uri TEXT PRIMARY KEY, line INTEGER)")
+        db.execSQL("CREATE TABLE IF NOT EXISTS bookmarks(uri TEXT PRIMARY KEY, line INTEGER, position INTEGER)")
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
-        if (oldVersion != newVersion) {
-            db.execSQL("DROP TABLE IF EXISTS settings")
+        if (oldVersion < 2) {
             db.execSQL("DROP TABLE IF EXISTS bookmarks")
-            onCreate(db)
+            db.execSQL("CREATE TABLE IF NOT EXISTS bookmarks(uri TEXT PRIMARY KEY, line INTEGER, position INTEGER)")
         }
     }
 
     companion object {
         private const val DATABASE_NAME = "app.db"
-        private const val DATABASE_VERSION = 1
+        private const val DATABASE_VERSION = 2
 
         @Volatile private var instance: DatabaseHelper? = null
 
@@ -59,22 +58,25 @@ object DatabaseManager {
         return default
     }
 
-    fun setBookmark(context: Context, uri: String, line: Int) {
+    fun setBookmark(context: Context, uri: String, line: Int, position: Int) {
         val values = ContentValues().apply {
             put("uri", uri)
             put("line", line)
+            put("position", position)
         }
         helper(context).writableDatabase.insertWithOnConflict(
             "bookmarks", null, values, SQLiteDatabase.CONFLICT_REPLACE
         )
     }
 
-    fun getBookmark(context: Context, uri: String): Int? {
+    fun getBookmark(context: Context, uri: String): Bookmark? {
         val db = helper(context).readableDatabase
-        db.query("bookmarks", arrayOf("line"), "uri=?", arrayOf(uri), null, null, null)
+        db.query("bookmarks", arrayOf("line", "position"), "uri=?", arrayOf(uri), null, null, null)
             .use { cursor ->
                 if (cursor.moveToFirst()) {
-                    return cursor.getInt(0)
+                    val line = cursor.getInt(0)
+                    val position = cursor.getInt(1)
+                    return Bookmark(line, position)
                 }
             }
         return null
@@ -84,3 +86,4 @@ object DatabaseManager {
         helper(context).writableDatabase.delete("bookmarks", "uri=?", arrayOf(uri))
     }
 }
+

--- a/app/src/main/java/com/example/kokoro82m/utils/FileNameUtils.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/FileNameUtils.kt
@@ -1,0 +1,11 @@
+package com.example.kokoro82m.utils
+
+import java.util.Locale
+
+fun buildStyleFileName(styles: List<String>, weights: Map<String, Float>, mode: InterpolationMode): String {
+    val parts = styles.map { s ->
+        val w = String.format(Locale.US, "%.2f", weights[s] ?: 1f)
+        "${s}_$w"
+    }
+    return (parts + mode.name.lowercase()).joinToString("-")
+}

--- a/app/src/main/java/com/example/kokoro82m/utils/WaveHelper.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/WaveHelper.kt
@@ -17,7 +17,7 @@ import java.util.Locale
 fun saveAudio(audioData: FloatArray, context: Context, name: String) {
     val sampleRate = 22050
 
-    val safeName = name.replace(Regex("[^a-zA-Z0-9_\-]"), "_")
+    val safeName = name.replace(Regex("""[^a-zA-Z0-9_\-]"""), "_")
     val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
 
     val contentValues = ContentValues().apply {

--- a/app/src/main/java/com/example/kokoro82m/utils/WaveHelper.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/WaveHelper.kt
@@ -14,14 +14,14 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-fun saveAudio(audioData: FloatArray, context: Context) {
+fun saveAudio(audioData: FloatArray, context: Context, name: String) {
     val sampleRate = 22050
 
-
+    val safeName = name.replace(Regex("[^a-zA-Z0-9_\-]"), "_")
     val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
 
     val contentValues = ContentValues().apply {
-        put(MediaStore.MediaColumns.DISPLAY_NAME, "KOKORO_$timeStamp.wav")
+        put(MediaStore.MediaColumns.DISPLAY_NAME, "${safeName}_$timeStamp.wav")
         put(MediaStore.MediaColumns.MIME_TYPE, "audio/wav")
         put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_MUSIC)
     }

--- a/app/src/test/java/com/example/kokoro82m/AudioPlayerSimpleTest.kt
+++ b/app/src/test/java/com/example/kokoro82m/AudioPlayerSimpleTest.kt
@@ -6,21 +6,26 @@ import kotlinx.coroutines.Dispatchers
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import android.media.AudioFormat
 class AudioPlayerSimpleTest {
-    lateinit var player: AudioPlayer
+    private lateinit var player: AudioPlayer
+    private lateinit var audioTrack: AudioTrack
+
     @Before
     fun setup() {
+        audioTrack = mock(AudioTrack::class.java)
         player = AudioPlayer(CoroutineScope(Dispatchers.Unconfined)) {}
         val field = AudioPlayer::class.java.getDeclaredField("audioTrack")
         field.isAccessible = true
-        field.set(player, null)
+        field.set(player, audioTrack)
         val logField = Class.forName("com.example.kokoro82m.utils.DebugLogger").getDeclaredField("logFile")
         logField.isAccessible = true
         logField.set(null, java.io.File.createTempFile("log", ".txt"))
         val pcmField = AudioPlayer::class.java.getDeclaredField("pcmData")
         pcmField.isAccessible = true
-        pcmField.set(player, ByteArray(0))
+        pcmField.set(player, ByteArray(100))
     }
 
     @Test
@@ -28,10 +33,12 @@ class AudioPlayerSimpleTest {
         val stateField = AudioPlayer::class.java.getDeclaredField("currentState")
         stateField.isAccessible = true
         stateField.set(player, PlayerState.PLAYING)
+        `when`(audioTrack.playbackHeadPosition).thenReturn(50)
 
         player.pause()
 
-        assertEquals(PlayerState.PAUSED, stateField.get(player))
+        assertEquals(PlayerState.PAUSED, player.getState())
+        assertEquals(50, player.getPosition())
     }
 
     @Test
@@ -42,7 +49,7 @@ class AudioPlayerSimpleTest {
 
         player.play()
 
-        assertEquals(PlayerState.PLAYING, stateField.get(player))
+        assertEquals(PlayerState.PLAYING, player.getState())
     }
 
     @Test
@@ -53,6 +60,7 @@ class AudioPlayerSimpleTest {
 
         player.stop()
 
-        assertEquals(PlayerState.IDLE, stateField.get(player))
+        assertEquals(PlayerState.IDLE, player.getState())
+        assertEquals(0, player.getPosition())
     }
 }

--- a/app/src/test/java/com/example/kokoro82m/BookmarkManagerTest.kt
+++ b/app/src/test/java/com/example/kokoro82m/BookmarkManagerTest.kt
@@ -1,4 +1,5 @@
 import android.content.Context
+import com.example.kokoro82m.utils.Bookmark
 import com.example.kokoro82m.utils.BookmarkManager
 import com.example.kokoro82m.utils.DatabaseManager
 import org.junit.Assert.assertEquals
@@ -12,16 +13,17 @@ class BookmarkManagerTest {
     @Test
     fun saveLoadAndClearBookmark() {
         val uri = "sample"
+        val bookmark = Bookmark(5, 100)
         mockStatic(DatabaseManager::class.java).use { db ->
-            db.`when`<Int?> { DatabaseManager.getBookmark(context, uri) }.thenReturn(5)
-            BookmarkManager.save(context, uri, 5)
-            db.verify { DatabaseManager.setBookmark(context, uri, 5) }
-            assertEquals(5, BookmarkManager.load(context, uri))
+            db.`when`<Bookmark?> { DatabaseManager.getBookmark(context, uri) }.thenReturn(bookmark)
+            BookmarkManager.save(context, uri, 5, 100)
+            db.verify { DatabaseManager.setBookmark(context, uri, 5, 100) }
+            assertEquals(bookmark, BookmarkManager.load(context, uri))
 
-            db.`when`<Int?> { DatabaseManager.getBookmark(context, uri) }.thenReturn(null)
+            db.`when`<Bookmark?> { DatabaseManager.getBookmark(context, uri) }.thenReturn(null)
             BookmarkManager.clear(context, uri)
             db.verify { DatabaseManager.clearBookmark(context, uri) }
-            assertEquals(-1, BookmarkManager.load(context, uri))
+            assertEquals(null, BookmarkManager.load(context, uri))
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `buildStyleFileName` helper to create descriptive names
- update `WaveHelper.saveAudio` to take the desired name
- include style or voice name when saving from basic, mixer and book screens

## Testing
- `gradle help --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687b02bd6474833199b3f2b1c51bdb89