### PR TITLE
Add basic symbol replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Gradle Sync and Build
 ## Prebuilt apk files
 See [release](https://github.com/puff-dayo/Kokoro-82M-Android/releases/).
 
+## Text Sanitization
+Numbers and basic symbols like `-` are automatically expanded before
+tokenization. For example `1-2` becomes `one dash two`.
+
 ## TODO
 
 - Add a voice style mixer [Done]

--- a/app/src/main/java/com/example/kokoro82m/utils/PhonemeConverter.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/PhonemeConverter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.Resources
 import com.example.kokoro82m.R
 import com.github.medavox.ipa_transcribers.Language
+import com.example.kokoro82m.utils.SymbolDictionary
 import java.io.IOException
 
 class PhonemeConverter(context: Context) {
@@ -186,6 +187,9 @@ class PhonemeConverter(context: Context) {
 
         normalizedText = normalizedText.replace(Regex("(?<=\\d),(?=\\d)"), "")
         normalizedText = normalizedText.replace(Regex("(?<=\\d)-(?=\\d)"), " to ")
+
+        normalizedText = SymbolDictionary.replaceSymbols(normalizedText)
+        normalizedText = normalizedText.replace(Regex("\\s+"), " ")
 
         return normalizedText.trim()
     }

--- a/app/src/main/java/com/example/kokoro82m/utils/SymbolDictionary.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/SymbolDictionary.kt
@@ -1,0 +1,32 @@
+package com.example.kokoro82m.utils
+
+object SymbolDictionary {
+    private val map = mapOf(
+        '0' to "zero",
+        '1' to "one",
+        '2' to "two",
+        '3' to "three",
+        '4' to "four",
+        '5' to "five",
+        '6' to "six",
+        '7' to "seven",
+        '8' to "eight",
+        '9' to "nine",
+        '-' to "dash"
+    )
+
+    fun replaceSymbols(text: String): String {
+        val builder = StringBuilder()
+        for (ch in text) {
+            val replacement = map[ch]
+            if (replacement != null) {
+                builder.append(' ')
+                builder.append(replacement)
+                builder.append(' ')
+            } else {
+                builder.append(ch)
+            }
+        }
+        return builder.toString()
+    }
+}

--- a/app/src/test/java/com/example/kokoro82m/SymbolDictionaryTest.kt
+++ b/app/src/test/java/com/example/kokoro82m/SymbolDictionaryTest.kt
@@ -1,0 +1,16 @@
+package com.example.kokoro82m
+
+import com.example.kokoro82m.utils.SymbolDictionary
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SymbolDictionaryTest {
+    @Test
+    fun replaceSymbolsReplacesDigitsAndHyphen() {
+        val input = "Line 1-2"
+        val output = SymbolDictionary.replaceSymbols(input)
+            .replace("\\s+".toRegex(), " ")
+            .trim()
+        assertEquals("Line one dash two", output)
+    }
+}


### PR DESCRIPTION
## Summary
- support sanitizing digits and dashes before tokenization
- centralize replacements in `SymbolDictionary`
- document text sanitization in README
- add unit test for replacement logic

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c3ae14b248331840e9ee91559df1c