### PR TITLE
Enable background playback for BookScreen

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -25,8 +25,6 @@ import com.example.kokoro82m.utils.*
 import com.example.kokoro82m.viewmodel.BookViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -47,7 +45,6 @@ fun BookScreen(
     val bookUri by bookViewModel.bookUri.collectAsState()
     var bookmark by remember { mutableStateOf<Bookmark?>(null) }
 
-    var playJob by remember { mutableStateOf<Job?>(null) }
 
     val listState = rememberLazyListState()
 
@@ -179,9 +176,7 @@ fun BookScreen(
                                 BookmarkManager.save(context, it.toString(), currentLine, position)
                             }
                         } else {
-                            playJob?.cancel()
-                            playJob = playBook(
-                                scope = scope,
+                            bookViewModel.startPlayback(
                                 session = session,
                                 phonemeConverter = phonemeConverter,
                                 styleLoader = styleLoader,
@@ -192,14 +187,12 @@ fun BookScreen(
                                 lines = lines,
                                 startLine = currentLine.coerceAtLeast(0),
                                 bookUri = bookUri,
-                                audioPlayer = bookViewModel.audioPlayer,
                                 context = context,
-                                onLineChanged = { bookViewModel.setCurrentLine(it) },
+                                bookmark = bookmark,
                                 onFinished = {
                                     bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
                                     bookmark = null
                                 },
-                                bookmark = bookmark
                             )
                         }
                     },
@@ -216,8 +209,7 @@ fun BookScreen(
                 }
                 Button(
                     onClick = {
-                        bookViewModel.audioPlayer.stop()
-                        playJob?.cancel()
+                        bookViewModel.stopPlayback()
                     },
                     enabled = playerState != PlayerState.IDLE,
                     modifier = Modifier.weight(1f)
@@ -275,9 +267,7 @@ fun BookScreen(
                     .fillMaxWidth()
                     .clickable {
                         bookViewModel.setCurrentLine(index)
-                        playJob?.cancel() // Stop any existing playback
-                        playJob = playBook(
-                            scope = scope,
+                        bookViewModel.startPlayback(
                             session = session,
                             phonemeConverter = phonemeConverter,
                             styleLoader = styleLoader,
@@ -288,14 +278,12 @@ fun BookScreen(
                             lines = lines,
                             startLine = index,
                             bookUri = bookUri,
-                            audioPlayer = bookViewModel.audioPlayer,
                             context = context,
-                            onLineChanged = { bookViewModel.setCurrentLine(it) },
+                            bookmark = bookmark,
                             onFinished = {
                                 bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
                                 bookmark = null
                             },
-                            bookmark = bookmark
                         )
                     }
                     .background(if (index == currentLine) Color.Yellow else Color.Transparent)
@@ -322,101 +310,4 @@ fun BookScreen(
     }
 }
 
-private suspend fun playAudio(
-    line: String,
-    styleVector: Array<FloatArray>,
-    speed: Float,
-    session: OrtSession,
-    phonemeConverter: PhonemeConverter,
-    audioPlayer: AudioPlayer,
-    position: Int = 0
-) {
-    try {
-        DebugLogger.log("Playing audio for line: '$line' from position $position")
-        val phonemes = phonemeConverter.phonemize(line)
-        val (audio, _) = createAudioFromStyleVector(
-            phonemes = phonemes,
-            voice = styleVector,
-            speed = speed,
-            session = session
-        )
-        audioPlayer.prepare(audio, position)
-        audioPlayer.playBlocking()
-    } catch (e: Exception) {
-        DebugLogger.log("playAudio failed: ${e.localizedMessage}")
-    }
-}
-
-private fun playBook(
-    scope: CoroutineScope,
-    session: OrtSession,
-    phonemeConverter: PhonemeConverter,
-    styleLoader: StyleLoader,
-    selectedStyles: List<String>,
-    weights: Map<String, Float>,
-    mode: InterpolationMode,
-    speed: Float,
-    lines: List<String>,
-    startLine: Int,
-    bookUri: Uri?,
-    audioPlayer: AudioPlayer,
-    context: Context,
-    onLineChanged: (Int) -> Unit,
-    onFinished: () -> Unit,
-    bookmark: Bookmark?
-): Job {
-    return scope.launch(Dispatchers.IO) {
-        DebugLogger.log("Starting playbook from line $startLine")
-        var completed = true
-        try {
-            val mixedVector = mixStyles(
-                styleLoader = styleLoader,
-                styles = selectedStyles,
-                weights = weights,
-                mode = mode
-            )
-            for (index in startLine until lines.size) {
-                if (!isActive) {
-                    completed = false
-                    break
-                }
-
-                withContext(Dispatchers.Main) {
-                    onLineChanged(index)
-                }
-                val line = lines[index]
-                val position = if (index == bookmark?.line) bookmark.position else 0
-                DebugLogger.log("Playing line $index with position $position")
-
-                playAudio(
-                    line = line,
-                    styleVector = mixedVector,
-                    speed = speed,
-                    session = session,
-                    phonemeConverter = phonemeConverter,
-                    audioPlayer = audioPlayer,
-                    position = position
-                )
-
-                if (audioPlayer.getState() == PlayerState.PAUSED) {
-                    completed = false
-                    break
-                }
-            }
-        } catch (e: Exception) {
-            completed = false
-            DebugLogger.log("playBook failed: ${e.localizedMessage}")
-        } finally {
-            withContext(Dispatchers.Main) {
-                if (audioPlayer.getState() != PlayerState.PAUSED) {
-                    onLineChanged(-1)
-                    if (completed) {
-                        onFinished()
-                    }
-                    audioPlayer.stop()
-                }
-            }
-        }
-    }
-}
 

--- a/app/src/main/java/com/example/kokoro82m/utils/BookPlayer.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/BookPlayer.kt
@@ -1,0 +1,110 @@
+package com.example.kokoro82m.utils
+
+import ai.onnxruntime.OrtSession
+import android.content.Context
+import android.net.Uri
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+suspend fun playAudio(
+    line: String,
+    styleVector: Array<FloatArray>,
+    speed: Float,
+    session: OrtSession,
+    phonemeConverter: PhonemeConverter,
+    audioPlayer: AudioPlayer,
+    position: Int = 0,
+) {
+    try {
+        DebugLogger.log("Playing audio for line: '$line' from position $position")
+        val phonemes = phonemeConverter.phonemize(line)
+        val (audio, _) = createAudioFromStyleVector(
+            phonemes = phonemes,
+            voice = styleVector,
+            speed = speed,
+            session = session,
+        )
+        audioPlayer.prepare(audio, position)
+        audioPlayer.playBlocking()
+    } catch (e: Exception) {
+        DebugLogger.log("playAudio failed: ${e.localizedMessage}")
+    }
+}
+
+fun playBook(
+    scope: CoroutineScope,
+    session: OrtSession,
+    phonemeConverter: PhonemeConverter,
+    styleLoader: StyleLoader,
+    selectedStyles: List<String>,
+    weights: Map<String, Float>,
+    mode: InterpolationMode,
+    speed: Float,
+    lines: List<String>,
+    startLine: Int,
+    bookUri: Uri?,
+    audioPlayer: AudioPlayer,
+    context: Context,
+    onLineChanged: (Int) -> Unit,
+    onFinished: () -> Unit,
+    bookmark: Bookmark?,
+): Job {
+    return scope.launch(Dispatchers.IO) {
+        DebugLogger.log("Starting playbook from line $startLine")
+        var completed = true
+        try {
+            val mixedVector = mixStyles(
+                styleLoader = styleLoader,
+                styles = selectedStyles,
+                weights = weights,
+                mode = mode,
+            )
+            for (index in startLine until lines.size) {
+                if (!isActive) {
+                    completed = false
+                    break
+                }
+
+                withContext(Dispatchers.Main) {
+                    onLineChanged(index)
+                }
+                val line = lines[index]
+                val position = if (index == bookmark?.line) bookmark.position else 0
+                DebugLogger.log("Playing line $index with position $position")
+
+                playAudio(
+                    line = line,
+                    styleVector = mixedVector,
+                    speed = speed,
+                    session = session,
+                    phonemeConverter = phonemeConverter,
+                    audioPlayer = audioPlayer,
+                    position = position,
+                )
+
+                if (audioPlayer.getState() == PlayerState.PAUSED) {
+                    completed = false
+                    break
+                }
+            }
+        } catch (e: Exception) {
+            completed = false
+            DebugLogger.log("playBook failed: ${e.localizedMessage}")
+        } finally {
+            withContext(Dispatchers.Main) {
+                if (audioPlayer.getState() != PlayerState.PAUSED) {
+                    onLineChanged(-1)
+                    if (completed) {
+                        onFinished()
+                    }
+                    audioPlayer.stop()
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
@@ -4,12 +4,19 @@ import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import ai.onnxruntime.OrtSession
 import com.example.kokoro82m.utils.AudioPlayer
+import com.example.kokoro82m.utils.Bookmark
+import com.example.kokoro82m.utils.InterpolationMode
+import com.example.kokoro82m.utils.PhonemeConverter
 import com.example.kokoro82m.utils.PlayerState
+import com.example.kokoro82m.utils.StyleLoader
+import com.example.kokoro82m.utils.playBook
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class BookViewModel : ViewModel() {
@@ -30,6 +37,8 @@ class BookViewModel : ViewModel() {
         onStateChanged = { _playerState.value = it }
     )
 
+    private var playJob: Job? = null
+
     fun loadBook(context: Context, uri: Uri) {
         _bookUri.value = uri
         viewModelScope.launch(Dispatchers.IO) {
@@ -42,5 +51,47 @@ class BookViewModel : ViewModel() {
 
     fun setCurrentLine(line: Int) {
         _currentLine.value = line
+    }
+
+    fun startPlayback(
+        session: OrtSession,
+        phonemeConverter: PhonemeConverter,
+        styleLoader: StyleLoader,
+        selectedStyles: List<String>,
+        weights: Map<String, Float>,
+        mode: InterpolationMode,
+        speed: Float,
+        lines: List<String>,
+        startLine: Int,
+        bookUri: Uri?,
+        context: Context,
+        bookmark: Bookmark?,
+        onFinished: () -> Unit,
+    ) {
+        playJob?.cancel()
+        playJob = playBook(
+            scope = viewModelScope,
+            session = session,
+            phonemeConverter = phonemeConverter,
+            styleLoader = styleLoader,
+            selectedStyles = selectedStyles,
+            weights = weights,
+            mode = mode,
+            speed = speed,
+            lines = lines,
+            startLine = startLine,
+            bookUri = bookUri,
+            audioPlayer = audioPlayer,
+            context = context,
+            onLineChanged = { setCurrentLine(it) },
+            onFinished = onFinished,
+            bookmark = bookmark,
+        )
+    }
+
+    fun stopPlayback() {
+        playJob?.cancel()
+        playJob = null
+        audioPlayer.stop()
     }
 }


### PR DESCRIPTION
## Summary
- add `BookPlayer` utility with play functions
- manage playback in `BookViewModel` using `startPlayback` and `stopPlayback`
- update `BookScreen` to use the ViewModel's playback methods

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c4d6c92d08331900bef79bfb0f485