### PR TITLE
Add experimental MediaPipe LLM chat feature

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,7 @@ dependencies {
 
     val work_version = "2.9.0"
     implementation("androidx.work:work-runtime-ktx:$work_version")
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
 }
 
 tasks.withType<JavaCompile> {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,12 @@ android {
 }
 
 dependencies {
+    implementation("com.google.ai.edge.litert:litert:2.0.1-alpha")
+    runtimeOnly("com.google.ai.edge.litert:litert-gpu:2.0.1-alpha")
+    implementation("com.google.mediapipe:tasks-core:0.10.26")
+    implementation("com.google.mediapipe:tasks-genai:0.10.26")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,10 +44,10 @@ android {
 }
 
 dependencies {
-    implementation("com.google.ai.edge.litert:litert:2.0.1-alpha")
-    runtimeOnly("com.google.ai.edge.litert:litert-gpu:2.0.1-alpha")
-    implementation("com.google.mediapipe:tasks-core:0.10.26")
-    implementation("com.google.mediapipe:tasks-genai:0.10.26")
+    implementation("com.google.ai.edge.litert:litert:1.0.1")
+    runtimeOnly("com.google.ai.edge.litert:litert-gpu:1.0.1")
+    implementation("com.google.mediapipe:tasks-core:latest.release")
+    implementation("com.google.mediapipe:tasks-genai:latest.release")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
     implementation("com.google.ai.edge.litert:litert:1.0.1")
     runtimeOnly("com.google.ai.edge.litert:litert-gpu:1.0.1")
     implementation("com.google.mediapipe:tasks-core:latest.release")
-    implementation("com.google.mediapipe:tasks-genai:latest.release")
+    implementation("com.google.mediapipe:tasks-genai:0.10.14")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,6 +85,9 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:$lifecycle_version")
+
+    val work_version = "2.9.0"
+    implementation("androidx.work:work-runtime-ktx:$work_version")
 }
 
 tasks.withType<JavaCompile> {

--- a/app/gemini.md
+++ b/app/gemini.md
@@ -1,0 +1,243 @@
+Executing tasks: [:app:assembleDebug] in project /Users/luisocampo/AndroidStudioProjects/Kokoro-82M-Android
+
+> Task :app:preBuild UP-TO-DATE
+> Task :app:preDebugBuild UP-TO-DATE
+> Task :app:mergeDebugNativeDebugMetadata NO-SOURCE
+> Task :app:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :app:checkDebugAarMetadata UP-TO-DATE
+> Task :app:generateDebugResValues UP-TO-DATE
+> Task :app:mapDebugSourceSetPaths UP-TO-DATE
+> Task :app:generateDebugResources UP-TO-DATE
+> Task :app:mergeDebugResources UP-TO-DATE
+> Task :app:packageDebugResources UP-TO-DATE
+> Task :app:parseDebugLocalResources UP-TO-DATE
+> Task :app:createDebugCompatibleScreenManifests UP-TO-DATE
+> Task :app:extractDeepLinksDebug UP-TO-DATE
+> Task :app:processDebugMainManifest UP-TO-DATE
+> Task :app:processDebugManifest UP-TO-DATE
+> Task :app:processDebugManifestForPackage UP-TO-DATE
+> Task :app:processDebugResources UP-TO-DATE
+> Task :app:javaPreCompileDebug UP-TO-DATE
+> Task :app:mergeDebugShaders UP-TO-DATE
+> Task :app:compileDebugShaders NO-SOURCE
+> Task :app:generateDebugAssets UP-TO-DATE
+> Task :app:mergeDebugAssets UP-TO-DATE
+> Task :app:compressDebugAssets UP-TO-DATE
+> Task :app:checkDebugDuplicateClasses UP-TO-DATE
+> Task :app:desugarDebugFileDependencies UP-TO-DATE
+> Task :app:mergeExtDexDebug UP-TO-DATE
+> Task :app:mergeLibDexDebug UP-TO-DATE
+> Task :app:mergeDebugJniLibFolders UP-TO-DATE
+> Task :app:mergeDebugNativeLibs UP-TO-DATE
+> Task :app:stripDebugDebugSymbols UP-TO-DATE
+> Task :app:validateSigningDebug UP-TO-DATE
+> Task :app:writeDebugAppMetadata UP-TO-DATE
+> Task :app:writeDebugSigningConfigVersions UP-TO-DATE
+
+> Task :app:compileDebugKotlin FAILED
+e: file:///Users/luisocampo/AndroidStudioProjects/Kokoro-82M-Android/app/src/main/java/com/example/kokoro/galleryport/AskImagePipeline.kt:15:17 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'com.example.kokoro.galleryport.LlmController?'.
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':app:compileDebugKotlin'.
+> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
+   > Compilation error. See log for more details
+
+* Try:
+> Run with --info or --debug option to get more log output.
+> Run with --scan to get full insights.
+> Get more help at https://help.gradle.org.
+
+* Exception is:
+org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':app:compileDebugKotlin'.
+	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.lambda$executeIfValid$1(ExecuteActionsTaskExecuter.java:130)
+	at org.gradle.internal.Try$Failure.ifSuccessfulOrElse(Try.java:293)
+	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:128)
+	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:116)
+	at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
+	at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:51)
+	at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
+	at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:74)
+	at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
+	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
+	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
+	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:209)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
+	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
+	at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:42)
+	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:331)
+	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:318)
+	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.lambda$execute$0(DefaultTaskExecutionGraph.java:314)
+	at org.gradle.internal.operations.CurrentBuildOperationRef.with(CurrentBuildOperationRef.java:85)
+	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:314)
+	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:303)
+	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:459)
+	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:376)
+	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
+	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:48)
+Caused by: org.gradle.workers.internal.DefaultWorkerExecutor$WorkExecutionException: A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
+	at org.gradle.workers.internal.DefaultWorkerExecutor$WorkItemExecution.waitForCompletion(DefaultWorkerExecutor.java:287)
+	at org.gradle.internal.work.DefaultAsyncWorkTracker.lambda$waitForItemsAndGatherFailures$2(DefaultAsyncWorkTracker.java:130)
+	at org.gradle.internal.Factories$1.create(Factories.java:31)
+	at org.gradle.internal.work.DefaultWorkerLeaseService.withoutLocks(DefaultWorkerLeaseService.java:335)
+	at org.gradle.internal.work.DefaultWorkerLeaseService.withoutLocks(DefaultWorkerLeaseService.java:318)
+	at org.gradle.internal.work.DefaultWorkerLeaseService.withoutLock(DefaultWorkerLeaseService.java:323)
+	at org.gradle.internal.work.DefaultAsyncWorkTracker.waitForItemsAndGatherFailures(DefaultAsyncWorkTracker.java:126)
+	at org.gradle.internal.work.DefaultAsyncWorkTracker.waitForItemsAndGatherFailures(DefaultAsyncWorkTracker.java:92)
+	at org.gradle.internal.work.DefaultAsyncWorkTracker.waitForAll(DefaultAsyncWorkTracker.java:78)
+	at org.gradle.internal.work.DefaultAsyncWorkTracker.waitForCompletion(DefaultAsyncWorkTracker.java:66)
+	at org.gradle.api.internal.tasks.execution.TaskExecution$3.run(TaskExecution.java:252)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:26)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.run(DefaultBuildOperationRunner.java:47)
+	at org.gradle.api.internal.tasks.execution.TaskExecution.executeAction(TaskExecution.java:229)
+	at org.gradle.api.internal.tasks.execution.TaskExecution.executeActions(TaskExecution.java:212)
+	at org.gradle.api.internal.tasks.execution.TaskExecution.executeWithPreviousOutputFiles(TaskExecution.java:195)
+	at org.gradle.api.internal.tasks.execution.TaskExecution.execute(TaskExecution.java:162)
+	at org.gradle.internal.execution.steps.ExecuteStep.executeInternal(ExecuteStep.java:105)
+	at org.gradle.internal.execution.steps.ExecuteStep.access$000(ExecuteStep.java:44)
+	at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:59)
+	at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:56)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:209)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
+	at org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:56)
+	at org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:44)
+	at org.gradle.internal.execution.steps.CancelExecutionStep.execute(CancelExecutionStep.java:42)
+	at org.gradle.internal.execution.steps.TimeoutStep.executeWithoutTimeout(TimeoutStep.java:75)
+	at org.gradle.internal.execution.steps.TimeoutStep.execute(TimeoutStep.java:55)
+	at org.gradle.internal.execution.steps.PreCreateOutputParentsStep.execute(PreCreateOutputParentsStep.java:50)
+	at org.gradle.internal.execution.steps.PreCreateOutputParentsStep.execute(PreCreateOutputParentsStep.java:28)
+	at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.execute(RemovePreviousOutputsStep.java:67)
+	at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.execute(RemovePreviousOutputsStep.java:37)
+	at org.gradle.internal.execution.steps.BroadcastChangingOutputsStep.execute(BroadcastChangingOutputsStep.java:61)
+	at org.gradle.internal.execution.steps.BroadcastChangingOutputsStep.execute(BroadcastChangingOutputsStep.java:26)
+	at org.gradle.internal.execution.steps.CaptureOutputsAfterExecutionStep.execute(CaptureOutputsAfterExecutionStep.java:69)
+	at org.gradle.internal.execution.steps.CaptureOutputsAfterExecutionStep.execute(CaptureOutputsAfterExecutionStep.java:46)
+	at org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:40)
+	at org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:29)
+	at org.gradle.internal.execution.steps.BuildCacheStep.executeWithoutCache(BuildCacheStep.java:189)
+	at org.gradle.internal.execution.steps.BuildCacheStep.lambda$execute$1(BuildCacheStep.java:75)
+	at org.gradle.internal.Either$Right.fold(Either.java:175)
+	at org.gradle.internal.execution.caching.CachingState.fold(CachingState.java:62)
+	at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:73)
+	at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:48)
+	at org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:46)
+	at org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:35)
+	at org.gradle.internal.execution.steps.SkipUpToDateStep.executeBecause(SkipUpToDateStep.java:75)
+	at org.gradle.internal.execution.steps.SkipUpToDateStep.lambda$execute$2(SkipUpToDateStep.java:53)
+	at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:53)
+	at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:35)
+	at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:37)
+	at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:27)
+	at org.gradle.internal.execution.steps.ResolveIncrementalCachingStateStep.executeDelegate(ResolveIncrementalCachingStateStep.java:49)
+	at org.gradle.internal.execution.steps.ResolveIncrementalCachingStateStep.executeDelegate(ResolveIncrementalCachingStateStep.java:27)
+	at org.gradle.internal.execution.steps.AbstractResolveCachingStateStep.execute(AbstractResolveCachingStateStep.java:71)
+	at org.gradle.internal.execution.steps.AbstractResolveCachingStateStep.execute(AbstractResolveCachingStateStep.java:39)
+	at org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:65)
+	at org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:36)
+	at org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:107)
+	at org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:56)
+	at org.gradle.internal.execution.steps.AbstractCaptureStateBeforeExecutionStep.execute(AbstractCaptureStateBeforeExecutionStep.java:64)
+	at org.gradle.internal.execution.steps.AbstractCaptureStateBeforeExecutionStep.execute(AbstractCaptureStateBeforeExecutionStep.java:43)
+	at org.gradle.internal.execution.steps.AbstractSkipEmptyWorkStep.executeWithNonEmptySources(AbstractSkipEmptyWorkStep.java:125)
+	at org.gradle.internal.execution.steps.AbstractSkipEmptyWorkStep.execute(AbstractSkipEmptyWorkStep.java:61)
+	at org.gradle.internal.execution.steps.AbstractSkipEmptyWorkStep.execute(AbstractSkipEmptyWorkStep.java:36)
+	at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsStartedStep.execute(MarkSnapshottingInputsStartedStep.java:38)
+	at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:36)
+	at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:23)
+	at org.gradle.internal.execution.steps.HandleStaleOutputsStep.execute(HandleStaleOutputsStep.java:75)
+	at org.gradle.internal.execution.steps.HandleStaleOutputsStep.execute(HandleStaleOutputsStep.java:41)
+	at org.gradle.internal.execution.steps.AssignMutableWorkspaceStep.lambda$execute$0(AssignMutableWorkspaceStep.java:35)
+	at org.gradle.api.internal.tasks.execution.TaskExecution$4.withWorkspace(TaskExecution.java:289)
+	at org.gradle.internal.execution.steps.AssignMutableWorkspaceStep.execute(AssignMutableWorkspaceStep.java:31)
+	at org.gradle.internal.execution.steps.AssignMutableWorkspaceStep.execute(AssignMutableWorkspaceStep.java:22)
+	at org.gradle.internal.execution.steps.ChoosePipelineStep.execute(ChoosePipelineStep.java:40)
+	at org.gradle.internal.execution.steps.ChoosePipelineStep.execute(ChoosePipelineStep.java:23)
+	at org.gradle.internal.execution.steps.ExecuteWorkBuildOperationFiringStep.lambda$execute$2(ExecuteWorkBuildOperationFiringStep.java:67)
+	at org.gradle.internal.execution.steps.ExecuteWorkBuildOperationFiringStep.execute(ExecuteWorkBuildOperationFiringStep.java:67)
+	at org.gradle.internal.execution.steps.ExecuteWorkBuildOperationFiringStep.execute(ExecuteWorkBuildOperationFiringStep.java:39)
+	at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:46)
+	at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:34)
+	at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:48)
+	at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:35)
+	at org.gradle.internal.execution.impl.DefaultExecutionEngine$1.execute(DefaultExecutionEngine.java:61)
+	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:127)
+	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:116)
+	at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
+	at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:51)
+	at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
+	at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:74)
+	at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
+	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
+	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
+	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:209)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
+	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
+	at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:42)
+	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:331)
+	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:318)
+	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.lambda$execute$0(DefaultTaskExecutionGraph.java:314)
+	at org.gradle.internal.operations.CurrentBuildOperationRef.with(CurrentBuildOperationRef.java:85)
+	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:314)
+	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:303)
+	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:459)
+	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:376)
+	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
+	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:48)
+Caused by: org.jetbrains.kotlin.gradle.tasks.CompilationErrorException: Compilation error. See log for more details
+	at org.jetbrains.kotlin.gradle.tasks.TasksUtilsKt.throwExceptionIfCompilationFailed(tasksUtils.kt:21)
+	at org.jetbrains.kotlin.compilerRunner.GradleKotlinCompilerWork.run(GradleKotlinCompilerWork.kt:119)
+	at org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction.execute(GradleCompilerRunnerWithWorkers.kt:76)
+	at org.gradle.workers.internal.DefaultWorkerServer.execute(DefaultWorkerServer.java:63)
+	at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:66)
+	at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:62)
+	at org.gradle.internal.classloader.ClassLoaderUtils.executeInClassloader(ClassLoaderUtils.java:100)
+	at org.gradle.workers.internal.NoIsolationWorkerFactory$1.lambda$execute$0(NoIsolationWorkerFactory.java:62)
+	at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:44)
+	at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:41)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:209)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
+	at org.gradle.workers.internal.AbstractWorker.executeWrappedInBuildOperation(AbstractWorker.java:41)
+	at org.gradle.workers.internal.NoIsolationWorkerFactory$1.execute(NoIsolationWorkerFactory.java:59)
+	at org.gradle.workers.internal.DefaultWorkerExecutor.lambda$submitWork$0(DefaultWorkerExecutor.java:174)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runExecution(DefaultConditionalExecutionQueue.java:194)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.access$700(DefaultConditionalExecutionQueue.java:127)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner$1.run(DefaultConditionalExecutionQueue.java:169)
+	at org.gradle.internal.Factories$1.create(Factories.java:31)
+	at org.gradle.internal.work.DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:263)
+	at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:127)
+	at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:132)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runBatch(DefaultConditionalExecutionQueue.java:164)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.run(DefaultConditionalExecutionQueue.java:133)
+	... 2 more
+
+
+BUILD FAILED in 1s
+28 actionable tasks: 1 executed, 27 up-to-date

--- a/app/src/main/java/com/example/kokoro/galleryport/AskImagePipeline.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/AskImagePipeline.kt
@@ -1,0 +1,25 @@
+package com.example.kokoro.galleryport
+
+import android.content.Context
+import android.graphics.Bitmap
+import com.google.mediapipe.tasks.vision.core.functional.BitmapImageBuilder
+import com.google.mediapipe.tasks.genai.llminference.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+object AskImagePipeline {
+    suspend fun run(ctx: Context, bitmap: Bitmap, q: String): Flow<String> = callbackFlow {
+        val ctrl = LlmController.bootstrap(ctx)
+        val sess = LlmInferenceSession.createFromOptions(
+            ctrl.llm,
+            LlmInferenceSession.LlmInferenceSessionOptions.builder()
+                .setGraphOptions(GraphOptions.builder().setEnableVisionModality(true).build())
+                .build()
+        )
+        sess.addImage(BitmapImageBuilder(bitmap).build())
+        sess.addQueryChunk(q)
+        sess.generateResponseAsync { res, done ->
+            trySend(res.partialText); done
+        }
+    }
+}

--- a/app/src/main/java/com/example/kokoro/galleryport/AskImagePipeline.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/AskImagePipeline.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.callbackFlow
 
 object AskImagePipeline {
     suspend fun run(ctx: Context, bitmap: Bitmap, q: String): Flow<String> = callbackFlow {
-        val ctrl = LlmController.bootstrap(ctx)
+        val ctrl = LlmController.bootstrap(ctx, "gemma-3n-E4B-it-int4")
         if (ctrl == null) {
             close(IllegalStateException("LlmController could not be bootstrapped"))
             return@callbackFlow

--- a/app/src/main/java/com/example/kokoro/galleryport/AskImagePipeline.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/AskImagePipeline.kt
@@ -11,6 +11,10 @@ import kotlinx.coroutines.flow.callbackFlow
 object AskImagePipeline {
     suspend fun run(ctx: Context, bitmap: Bitmap, q: String): Flow<String> = callbackFlow {
         val ctrl = LlmController.bootstrap(ctx)
+        if (ctrl == null) {
+            close(IllegalStateException("LlmController could not be bootstrapped"))
+            return@callbackFlow
+        }
         val sess = LlmInferenceSession.createFromOptions(
             ctrl.llm,
             LlmInferenceSession.LlmInferenceSessionOptions.builder()

--- a/app/src/main/java/com/example/kokoro/galleryport/AskImagePipeline.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/AskImagePipeline.kt
@@ -2,9 +2,10 @@ package com.example.kokoro.galleryport
 
 import android.content.Context
 import android.graphics.Bitmap
-import com.google.mediapipe.tasks.vision.core.functional.BitmapImageBuilder
+import com.google.mediapipe.framework.image.BitmapImageBuilder
 import com.google.mediapipe.tasks.genai.llminference.*
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 
 object AskImagePipeline {
@@ -19,7 +20,11 @@ object AskImagePipeline {
         sess.addImage(BitmapImageBuilder(bitmap).build())
         sess.addQueryChunk(q)
         sess.generateResponseAsync { res, done ->
-            trySend(res.partialText); done
+            trySend(res)
+            if (done) {
+                close()
+            }
         }
+        awaitClose { }
     }
 }

--- a/app/src/main/java/com/example/kokoro/galleryport/LlmController.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/LlmController.kt
@@ -1,0 +1,34 @@
+package com.example.kokoro.galleryport
+
+import android.content.Context
+import com.google.mediapipe.tasks.genai.llminference.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import java.nio.MappedByteBuffer
+
+class LlmController private constructor(val llm: LlmInference) {
+
+    companion object {
+        suspend fun bootstrap(ctx: Context): LlmController {
+            val f = ModelHub.get(
+                ctx,
+                "https://huggingface.co/google/gemma-3n-E2B-it-litert-lm-preview/resolve/main/gemma-3n-E2B-it-int4.litertlm",
+                "gemma3n.litertlm"
+            )
+            val opts = LlmInferenceOptions.builder()
+                .setTaskBundle(f.asMappedByteBuffer())
+                .setMaxContextLength(4096)
+                .setPreferredBackend(LlmInference.Backend.CPU)
+                .build()
+            return LlmController(LlmInference.createFromOptions(ctx, opts))
+        }
+    }
+
+    fun stream(prompt: String): Flow<String> = callbackFlow {
+        llm.generateResponse(prompt) { token ->
+            trySend(token.text)
+            false
+        }
+        close()
+    }
+}

--- a/app/src/main/java/com/example/kokoro/galleryport/LlmController.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/LlmController.kt
@@ -3,6 +3,7 @@ package com.example.kokoro.galleryport
 import android.content.Context
 import com.google.mediapipe.tasks.genai.llminference.*
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import java.nio.MappedByteBuffer
 
@@ -10,25 +11,30 @@ class LlmController private constructor(val llm: LlmInference) {
 
     companion object {
         suspend fun bootstrap(ctx: Context): LlmController {
+            // This is the model we will be using. Feel free to change it to any other model.
+            val modelUrl = "https://huggingface.co/google/gemma-2b-it-cpu/resolve/main/gemma-2b-it-cpu-int4.bin"
+            val modelAlias = "gemma-2b-it-cpu-int4.bin"
+
             val f = ModelHub.get(
                 ctx,
-                "https://huggingface.co/google/gemma-3n-E2B-it-litert-lm-preview/resolve/main/gemma-3n-E2B-it-int4.litertlm",
-                "gemma3n.litertlm"
+                modelUrl,
+                modelAlias
             )
-            val opts = LlmInferenceOptions.builder()
-                .setTaskBundle(f.asMappedByteBuffer())
-                .setMaxContextLength(4096)
-                .setPreferredBackend(LlmInference.Backend.CPU)
+            val opts = LlmInference.LlmInferenceOptions.builder()
+                .setModelPath(f.absolutePath)
+                .setMaxTokens(4096)
                 .build()
             return LlmController(LlmInference.createFromOptions(ctx, opts))
         }
     }
 
     fun stream(prompt: String): Flow<String> = callbackFlow {
-        llm.generateResponse(prompt) { token ->
-            trySend(token.text)
-            false
+        llm.generateResponseAsync(prompt) { partialResult, done ->
+            partialResult?.let(::trySend)
+            if (done) {
+                close()
+            }
         }
-        close()
+        awaitClose { }
     }
 }

--- a/app/src/main/java/com/example/kokoro/galleryport/LlmController.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/LlmController.kt
@@ -10,10 +10,9 @@ import java.io.File
 class LlmController private constructor(val llm: LlmInference) {
 
     companion object {
-        private const val CHAT_MODEL_ID = "gemma-2b-it-cpu"
-        fun bootstrap(ctx: Context): LlmController? {
+        fun bootstrap(ctx: Context, modelId: String): LlmController? {
             val modelManager = com.example.kokoro82m.data.ModelManager(ctx)
-            val model = modelManager.getModel(CHAT_MODEL_ID)
+            val model = modelManager.getModel(modelId)
 
             if (model == null || !model.isDownloaded) {
                 return null

--- a/app/src/main/java/com/example/kokoro/galleryport/LlmController.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/LlmController.kt
@@ -5,23 +5,26 @@ import com.google.mediapipe.tasks.genai.llminference.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
-import java.nio.MappedByteBuffer
+import java.io.File
 
 class LlmController private constructor(val llm: LlmInference) {
 
     companion object {
-        suspend fun bootstrap(ctx: Context): LlmController {
-            // This is the model we will be using. Feel free to change it to any other model.
-            val modelUrl = "https://huggingface.co/google/gemma-2b-it-cpu/resolve/main/gemma-2b-it-cpu-int4.bin"
-            val modelAlias = "gemma-2b-it-cpu-int4.bin"
+        private const val CHAT_MODEL_ID = "gemma-2b-it-cpu"
+        fun bootstrap(ctx: Context): LlmController? {
+            val modelManager = com.example.kokoro82m.data.ModelManager(ctx)
+            val model = modelManager.getModel(CHAT_MODEL_ID)
 
-            val f = ModelHub.get(
-                ctx,
-                modelUrl,
-                modelAlias
-            )
+            if (model == null || !model.isDownloaded) {
+                return null
+            }
+
+            val modelFile = File(ctx.filesDir, "models/${model.id}.task")
+            if (!modelFile.exists()) return null
+
+
             val opts = LlmInference.LlmInferenceOptions.builder()
-                .setModelPath(f.absolutePath)
+                .setModelPath(modelFile.absolutePath)
                 .setMaxTokens(4096)
                 .build()
             return LlmController(LlmInference.createFromOptions(ctx, opts))

--- a/app/src/main/java/com/example/kokoro/galleryport/ModelHub.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/ModelHub.kt
@@ -1,0 +1,23 @@
+package com.example.kokoro.galleryport
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+
+object ModelHub {
+    private val client = OkHttpClient()
+
+    suspend fun get(ctx: Context, url: String, alias: String): File =
+        withContext(Dispatchers.IO) {
+            val dst = File(ctx.filesDir, alias)
+            if (!dst.exists()) {
+                client.newCall(Request.Builder().url(url).build()).execute().use { rsp ->
+                    dst.outputStream().use { rsp.body!!.byteStream().copyTo(it) }
+                }
+            }
+            dst
+        }
+}

--- a/app/src/main/java/com/example/kokoro/galleryport/ModelHub.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/ModelHub.kt
@@ -1,23 +1,15 @@
 package com.example.kokoro.galleryport
 
 import android.content.Context
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
+import com.example.kokoro82m.data.ModelManager
 import java.io.File
 
 object ModelHub {
-    private val client = OkHttpClient()
-
-    suspend fun get(ctx: Context, url: String, alias: String): File =
-        withContext(Dispatchers.IO) {
-            val dst = File(ctx.filesDir, alias)
-            if (!dst.exists()) {
-                client.newCall(Request.Builder().url(url).build()).execute().use { rsp ->
-                    dst.outputStream().use { rsp.body!!.byteStream().copyTo(it) }
-                }
-            }
-            dst
-        }
+    suspend fun get(ctx: Context, modelId: String): File? {
+        val modelManager = ModelManager(ctx)
+        val model = modelManager.getModel(modelId) ?: return null
+        if (!model.isDownloaded) return null
+        val modelFile = File(ctx.filesDir, "models/${model.id}.task")
+        return if (modelFile.exists()) modelFile else null
+    }
 }

--- a/app/src/main/java/com/example/kokoro/galleryport/PerfHud.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/PerfHud.kt
@@ -1,0 +1,31 @@
+package com.example.kokoro.galleryport
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlin.system.measureNanoTime
+
+object PerfHud {
+    private val stats: SnapshotStateMap<String, Float> = mutableStateMapOf()
+
+    inline fun <T> record(label: String, block: () -> T): T {
+        val ms = measureNanoTime(block) / 1e6f
+        stats[label] = ms
+        return block()
+    }
+
+    @Composable
+    fun Overlay() {
+        Column(Modifier.padding(6.dp)) {
+            stats.forEach { (k, v) ->
+                Text("$k: ${"%.1f".format(v)} ms", color = Color.White, fontSize = 12.sp)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/kokoro/galleryport/PerfHud.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/PerfHud.kt
@@ -3,8 +3,8 @@ package com.example.kokoro.galleryport
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
-import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -12,12 +12,13 @@ import androidx.compose.ui.unit.sp
 import kotlin.system.measureNanoTime
 
 object PerfHud {
-    private val stats: SnapshotStateMap<String, Float> = mutableStateMapOf()
+    private val stats = mutableStateMapOf<String, Float>()
 
-    inline fun <T> record(label: String, block: () -> T): T {
-        val ms = measureNanoTime(block) / 1e6f
+    fun <T> record(label: String, block: () -> T): T {
+        var result: T? = null
+        val ms = measureNanoTime { result = block() } / 1e6f
         stats[label] = ms
-        return block()
+        return result!!
     }
 
     @Composable

--- a/app/src/main/java/com/example/kokoro/galleryport/PromptLabPipeline.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/PromptLabPipeline.kt
@@ -1,0 +1,9 @@
+package com.example.kokoro.galleryport
+
+import android.content.Context
+import kotlinx.coroutines.flow.Flow
+
+object PromptLabPipeline {
+    suspend fun run(ctx: Context, prompt: String): Flow<String> =
+        LlmController.bootstrap(ctx).stream(prompt)
+}

--- a/app/src/main/java/com/example/kokoro/galleryport/PromptLabPipeline.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/PromptLabPipeline.kt
@@ -1,9 +1,0 @@
-package com.example.kokoro.galleryport
-
-import android.content.Context
-import kotlinx.coroutines.flow.Flow
-
-object PromptLabPipeline {
-    suspend fun run(ctx: Context, prompt: String): Flow<String> =
-        LlmController.bootstrap(ctx).stream(prompt)
-}

--- a/app/src/main/java/com/example/kokoro/ui/ChatScreen.kt
+++ b/app/src/main/java/com/example/kokoro/ui/ChatScreen.kt
@@ -1,0 +1,46 @@
+package com.example.kokoro.ui
+
+import android.content.Context
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewModelScope
+import com.example.kokoro.galleryport.PromptLabPipeline
+import com.example.kokoro.galleryport.PerfHud
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+@Composable
+fun ChatScreen(ctx: Context, hud: Boolean) {
+    val vm: ChatVM = viewModel()
+    val msgs by vm.msgs.collectAsState()
+
+    Scaffold { padding ->
+        Column(Modifier.padding(padding)) {
+            LazyColumn(Modifier.weight(1f)) {
+                items(msgs) { Text(it) }
+            }
+            var txt by remember { mutableStateOf("") }
+            Row {
+                TextField(txt, { txt = it }, Modifier.weight(1f))
+                Button(onClick = { vm.send(ctx, txt); txt = "" }) { Text("Send") }
+            }
+        }
+        if (hud) PerfHud.Overlay()
+    }
+}
+
+class ChatVM : ViewModel() {
+    val msgs = MutableStateFlow(listOf<String>())
+    fun send(ctx: Context, prompt: String) = viewModelScope.launch {
+        msgs.value += "> $prompt"
+        PromptLabPipeline.run(ctx, prompt).collect { tok ->
+            msgs.value = msgs.value.dropLast(1) + (msgs.value.last() + tok)
+        }
+    }
+}

--- a/app/src/main/java/com/example/kokoro/ui/ChatScreen.kt
+++ b/app/src/main/java/com/example/kokoro/ui/ChatScreen.kt
@@ -1,6 +1,5 @@
 package com.example.kokoro.ui
 
-import android.content.Context
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -10,20 +9,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.kokoro.galleryport.LlmController
 import com.example.kokoro.galleryport.PerfHud
+import com.example.kokoro82m.viewmodel.MainViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 
 @Composable
-fun ChatScreen(ctx: Context, hud: Boolean) {
-    val vm: ChatVM = viewModel { ChatVM(ctx) }
-    val msgs by vm.msgs.collectAsState()
-    val modelReady by vm.modelReady.collectAsState()
+fun ChatScreen(viewModel: MainViewModel, hud: Boolean) {
+    val msgs by viewModel.chatMessages.collectAsState()
+    val modelReady by viewModel.isLlmInitialized.collectAsState()
 
     Scaffold { padding ->
         Column(Modifier.padding(padding).fillMaxSize()) {
@@ -40,7 +34,7 @@ fun ChatScreen(ctx: Context, hud: Boolean) {
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
-                        text = "Please go to the 'Models' screen to download the 'Gemma 2B IT (CPU)' model.",
+                        text = "Please go to the 'Models' screen to download the 'Gemma 3n IT 4B' model.",
                         style = MaterialTheme.typography.bodyLarge,
                         textAlign = TextAlign.Center,
                         modifier = Modifier.padding(horizontal = 16.dp)
@@ -53,45 +47,10 @@ fun ChatScreen(ctx: Context, hud: Boolean) {
                 var txt by remember { mutableStateOf("") }
                 Row(modifier = Modifier.padding(8.dp)) {
                     TextField(txt, { txt = it }, Modifier.weight(1f))
-                    Button(onClick = { vm.send(txt); txt = "" }) { Text("Send") }
+                    Button(onClick = { viewModel.sendChatMessage(txt); txt = "" }) { Text("Send") }
                 }
             }
         }
         if (hud) PerfHud.Overlay()
-    }
-}
-
-class ChatVM(private val ctx: Context) : ViewModel() {
-    private val _msgs = MutableStateFlow(listOf<String>())
-    val msgs: StateFlow<List<String>> = _msgs
-
-    private val _modelReady = MutableStateFlow(false)
-    val modelReady: StateFlow<Boolean> = _modelReady
-
-    private var llmController: LlmController? = null
-
-    init {
-        viewModelScope.launch {
-            llmController = LlmController.bootstrap(ctx)
-            _modelReady.value = llmController != null
-            if (llmController == null) {
-                _msgs.value = listOf("Model not found. Please download it from the Models screen.")
-            } else {
-                _msgs.value = listOf("Model ready.")
-            }
-        }
-    }
-
-    fun send(prompt: String) {
-        if (llmController == null) return
-
-        viewModelScope.launch {
-            _msgs.value += "> $prompt"
-            var currentResponse = ""
-            llmController!!.stream(prompt).collect { tok ->
-                currentResponse += tok
-                _msgs.value = _msgs.value.dropLast(1) + ("> $prompt\n$currentResponse")
-            }
-        }
     }
 }

--- a/app/src/main/java/com/example/kokoro/ui/ChatScreen.kt
+++ b/app/src/main/java/com/example/kokoro/ui/ChatScreen.kt
@@ -6,41 +6,92 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewModelScope
-import com.example.kokoro.galleryport.PromptLabPipeline
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.kokoro.galleryport.LlmController
 import com.example.kokoro.galleryport.PerfHud
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 @Composable
 fun ChatScreen(ctx: Context, hud: Boolean) {
-    val vm: ChatVM = viewModel()
+    val vm: ChatVM = viewModel { ChatVM(ctx) }
     val msgs by vm.msgs.collectAsState()
+    val modelReady by vm.modelReady.collectAsState()
 
     Scaffold { padding ->
-        Column(Modifier.padding(padding)) {
-            LazyColumn(Modifier.weight(1f)) {
-                items(msgs) { Text(it) }
-            }
-            var txt by remember { mutableStateOf("") }
-            Row {
-                TextField(txt, { txt = it }, Modifier.weight(1f))
-                Button(onClick = { vm.send(ctx, txt); txt = "" }) { Text("Send") }
+        Column(Modifier.padding(padding).fillMaxSize()) {
+            if (!modelReady) {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = "Chat model not downloaded.",
+                        style = MaterialTheme.typography.headlineSmall,
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "Please go to the 'Models' screen to download the 'Gemma 2B IT (CPU)' model.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
+            } else {
+                LazyColumn(Modifier.weight(1f).padding(horizontal = 8.dp)) {
+                    items(msgs) { Text(it) }
+                }
+                var txt by remember { mutableStateOf("") }
+                Row(modifier = Modifier.padding(8.dp)) {
+                    TextField(txt, { txt = it }, Modifier.weight(1f))
+                    Button(onClick = { vm.send(txt); txt = "" }) { Text("Send") }
+                }
             }
         }
         if (hud) PerfHud.Overlay()
     }
 }
 
-class ChatVM : ViewModel() {
-    val msgs = MutableStateFlow(listOf<String>())
-    fun send(ctx: Context, prompt: String) = viewModelScope.launch {
-        msgs.value += "> $prompt"
-        PromptLabPipeline.run(ctx, prompt).collect { tok ->
-            msgs.value = msgs.value.dropLast(1) + (msgs.value.last() + tok)
+class ChatVM(private val ctx: Context) : ViewModel() {
+    private val _msgs = MutableStateFlow(listOf<String>())
+    val msgs: StateFlow<List<String>> = _msgs
+
+    private val _modelReady = MutableStateFlow(false)
+    val modelReady: StateFlow<Boolean> = _modelReady
+
+    private var llmController: LlmController? = null
+
+    init {
+        viewModelScope.launch {
+            llmController = LlmController.bootstrap(ctx)
+            _modelReady.value = llmController != null
+            if (llmController == null) {
+                _msgs.value = listOf("Model not found. Please download it from the Models screen.")
+            } else {
+                _msgs.value = listOf("Model ready.")
+            }
+        }
+    }
+
+    fun send(prompt: String) {
+        if (llmController == null) return
+
+        viewModelScope.launch {
+            _msgs.value += "> $prompt"
+            var currentResponse = ""
+            llmController!!.stream(prompt).collect { tok ->
+                currentResponse += tok
+                _msgs.value = _msgs.value.dropLast(1) + ("> $prompt\n$currentResponse")
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -6,6 +6,8 @@ import com.example.kokoro82m.screens.CreationsScreen
 import com.example.kokoro82m.screens.SettingsScreen
 import com.example.kokoro82m.screens.MixerScreen
 import com.example.kokoro82m.screens.MoreScreen
+import com.example.kokoro.ui.ChatScreen
+import com.example.kokoro.galleryport.PerfHud
 import ai.onnxruntime.OrtSession
 import android.app.Application
 import android.content.Context
@@ -145,10 +147,15 @@ private fun generateAudio(
             }
 
 
-            val (audioData, sampleRate) = createAudio(
-                voice = style, phonemes = phonemes, speed = speed, context = context,
-                session = session
-            )
+            val (audioData, sampleRate) = PerfHud.record("ONNX synth") {
+                createAudio(
+                    voice = style,
+                    phonemes = phonemes,
+                    speed = speed,
+                    context = context,
+                    session = session
+                )
+            }
 
             playAudio(
                 audioData, scope,
@@ -175,6 +182,7 @@ sealed class Screen(val title: String) {
     object Basic : Screen("Basic TTS")
     object Mixer : Screen("Mixer")
     object Book : Screen("Audio Book")
+    object Chat : Screen("Chat")
     object More : Screen("More")
     object Creations : Screen("Creations")
     object Settings : Screen("Settings")
@@ -189,12 +197,16 @@ fun MainScreen(
     onGenerateAudio: (String, String, Float, Boolean, () -> Unit) -> Unit
 ) {
     var currentScreen by remember { mutableStateOf<Screen>(Screen.Basic) }
+    var hudEnabled by remember { mutableStateOf(false) }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text(currentScreen.title) }
+                title = { Text(currentScreen.title) },
+                actions = {
+                    Switch(checked = hudEnabled, onCheckedChange = { hudEnabled = it })
+                }
             )
         },
         bottomBar = {
@@ -216,6 +228,12 @@ fun MainScreen(
                     label = { Text("Book") },
                     selected = currentScreen == Screen.Book,
                     onClick = { currentScreen = Screen.Book }
+                )
+                NavigationBarItem(
+                    icon = { Icon(Icons.Default.Info, contentDescription = "Chat") },
+                    label = { Text("Chat") },
+                    selected = currentScreen == Screen.Chat,
+                    onClick = { currentScreen = Screen.Chat }
                 )
                 NavigationBarItem(
                     icon = { Icon(Icons.Default.Info, contentDescription = "About") },
@@ -244,6 +262,7 @@ fun MainScreen(
                     session = session,
                     phonemeConverter = phonemeConverter
                 )
+                Screen.Chat -> ChatScreen(LocalContext.current, hudEnabled)
                 Screen.More -> MoreScreen { screen ->
                     currentScreen = when (screen) {
                         "Creations" -> Screen.Creations

--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.kokoro82m.data.UserPreferencesRepository
 import com.example.kokoro82m.screens.Acknowledgements
 import com.example.kokoro82m.utils.MainViewModel
 import com.example.kokoro82m.utils.PhonemeConverter
@@ -85,11 +86,13 @@ class MyApplication : Application() {
 class MainActivity : ComponentActivity() {
     private lateinit var phonemeConverter: PhonemeConverter
     private val scope = MainScope()
+    private lateinit var userPreferencesRepository: UserPreferencesRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         DebugLogger.initialize(this)
         enableEdgeToEdge()
+        userPreferencesRepository = UserPreferencesRepository(this)
 
         setContent {
             KokoroTheme {
@@ -115,7 +118,8 @@ class MainActivity : ComponentActivity() {
                             shouldSave,
                             onComplete
                         )
-                    }
+                    },
+                    userPreferencesRepository = userPreferencesRepository
                 )
             }
         }
@@ -197,7 +201,8 @@ sealed class Screen(val title: String) {
 fun MainScreen(
     session: OrtSession,
     phonemeConverter: PhonemeConverter,
-    onGenerateAudio: (String, String, Float, Boolean, () -> Unit) -> Unit
+    onGenerateAudio: (String, String, Float, Boolean, () -> Unit) -> Unit,
+    userPreferencesRepository: UserPreferencesRepository
 ) {
     var currentScreen by remember { mutableStateOf<Screen>(Screen.Basic) }
     var hudEnabled by remember { mutableStateOf(false) }
@@ -279,7 +284,7 @@ fun MainScreen(
                 Screen.Creations -> CreationsScreen()
                 Screen.Settings -> SettingsScreen()
                 Screen.About -> AboutScreen()
-                Screen.Models -> ModelsScreen()
+                Screen.Models -> ModelsScreen(userPreferencesRepository)
             }
         }
     }

--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -6,6 +6,7 @@ import com.example.kokoro82m.screens.CreationsScreen
 import com.example.kokoro82m.screens.SettingsScreen
 import com.example.kokoro82m.screens.MixerScreen
 import com.example.kokoro82m.screens.MoreScreen
+import com.example.kokoro82m.screens.ModelsScreen
 import com.example.kokoro.ui.ChatScreen
 import com.example.kokoro.galleryport.PerfHud
 import ai.onnxruntime.OrtSession
@@ -188,6 +189,7 @@ sealed class Screen(val title: String) {
     object Creations : Screen("Creations")
     object Settings : Screen("Settings")
     object About : Screen("About this app")
+    object Models : Screen("Models")
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -199,6 +201,8 @@ fun MainScreen(
 ) {
     var currentScreen by remember { mutableStateOf<Screen>(Screen.Basic) }
     var hudEnabled by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    val viewModel: MainViewModel = viewModel { MainViewModel(context) }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -253,27 +257,29 @@ fun MainScreen(
     ) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) {
             when (currentScreen) {
-                Screen.Basic -> BasicScreen(session = session, onGenerateAudio)
+                Screen.Basic -> BasicScreen(session = session, onGenerateAudio = onGenerateAudio, viewModel = viewModel)
                 Screen.Mixer -> MixerScreen(
                     session = session,
                     phonemeConverter = phonemeConverter,
-                    styleLoader = StyleLoader(LocalContext.current)
+                    styleLoader = StyleLoader(context)
                 )
                 Screen.Book -> BookScreen(
                     session = session,
                     phonemeConverter = phonemeConverter
                 )
-                Screen.Chat -> ChatScreen(LocalContext.current, hudEnabled)
+                Screen.Chat -> ChatScreen(context, hudEnabled)
                 Screen.More -> MoreScreen { screen ->
                     currentScreen = when (screen) {
                         "Creations" -> Screen.Creations
                         "Settings" -> Screen.Settings
+                        "Models" -> Screen.Models
                         else -> currentScreen
                     }
                 }
                 Screen.Creations -> CreationsScreen()
                 Screen.Settings -> SettingsScreen()
                 Screen.About -> AboutScreen()
+                Screen.Models -> ModelsScreen()
             }
         }
     }
@@ -283,7 +289,8 @@ fun MainScreen(
 @Composable
 fun BasicScreen(
     session: OrtSession,
-    onGenerateAudio: (String, String, Float, Boolean, () -> Unit) -> Unit
+    onGenerateAudio: (String, String, Float, Boolean, () -> Unit) -> Unit,
+    viewModel: MainViewModel
 ) {
     val context = LocalContext.current
     var text by remember { mutableStateOf("This is her warm heart, her warmest kokoro, unwavering love and comfort.") }
@@ -291,6 +298,17 @@ fun BasicScreen(
     var speed by remember { mutableFloatStateOf(SettingsManager.getSpeed(context)) }
     var isProcessing by remember { mutableStateOf(false) }
     var shouldSaveFile by remember { mutableStateOf(false) }
+
+    val modelManager = remember { com.example.kokoro82m.data.ModelManager(context) }
+    val models = remember { modelManager.models.filter { it.isDownloaded } }
+    var selectedModel by remember { mutableStateOf(models.firstOrNull()) }
+
+    LaunchedEffect(selectedModel) {
+        selectedModel?.let {
+            val modelFile = java.io.File(context.filesDir, "models/${it.id}.task")
+            viewModel.reinitializeSession(modelFile.absolutePath)
+        }
+    }
 
     val names = listOf(
         "af",
@@ -306,6 +324,7 @@ fun BasicScreen(
         "bm_lewis"
     )
     var expanded by remember { mutableStateOf(false) }
+    var modelExpanded by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -324,6 +343,40 @@ fun BasicScreen(
                 keyboardType = KeyboardType.Text
             )
         )
+
+        ExposedDropdownMenuBox(
+            expanded = modelExpanded,
+            onExpandedChange = { modelExpanded = !modelExpanded },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            TextField(
+                value = selectedModel?.name ?: "Select a model",
+                onValueChange = { },
+                label = { Text("Model") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(),
+                readOnly = true,
+                trailingIcon = {
+                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = modelExpanded)
+                }
+            )
+
+            ExposedDropdownMenu(
+                expanded = modelExpanded,
+                onDismissRequest = { modelExpanded = false }
+            ) {
+                models.forEach { model ->
+                    DropdownMenuItem(
+                        text = { Text(model.name) },
+                        onClick = {
+                            selectedModel = model
+                            modelExpanded = false
+                        }
+                    )
+                }
+            }
+        }
 
         ExposedDropdownMenuBox(
             expanded = expanded,

--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -60,7 +60,7 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.kokoro82m.data.UserPreferencesRepository
 import com.example.kokoro82m.screens.Acknowledgements
-import com.example.kokoro82m.utils.MainViewModel
+import com.example.kokoro82m.viewmodel.MainViewModel
 import com.example.kokoro82m.utils.PhonemeConverter
 import com.example.kokoro82m.utils.StyleLoader
 import com.example.kokoro82m.utils.createAudio
@@ -101,14 +101,12 @@ class MainActivity : ComponentActivity() {
                 }
 
                 val viewModel: MainViewModel = viewModel { MainViewModel(this@MainActivity) }
-                val session = remember { viewModel.getSession() }
 
                 MainScreen(
-                    session = session,
                     phonemeConverter = phonemeConverter,
                     onGenerateAudio = { text, style, speed, shouldSave, onComplete ->
                         generateAudio(
-                            session,
+                            viewModel.getSession(),
                             phonemeConverter,
                             text,
                             style,
@@ -199,7 +197,6 @@ sealed class Screen(val title: String) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(
-    session: OrtSession,
     phonemeConverter: PhonemeConverter,
     onGenerateAudio: (String, String, Float, Boolean, () -> Unit) -> Unit,
     userPreferencesRepository: UserPreferencesRepository
@@ -262,17 +259,17 @@ fun MainScreen(
     ) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) {
             when (currentScreen) {
-                Screen.Basic -> BasicScreen(session = session, onGenerateAudio = onGenerateAudio, viewModel = viewModel)
+                Screen.Basic -> BasicScreen(onGenerateAudio = onGenerateAudio, viewModel = viewModel)
                 Screen.Mixer -> MixerScreen(
-                    session = session,
+                    session = viewModel.getSession(),
                     phonemeConverter = phonemeConverter,
                     styleLoader = StyleLoader(context)
                 )
                 Screen.Book -> BookScreen(
-                    session = session,
+                    session = viewModel.getSession(),
                     phonemeConverter = phonemeConverter
                 )
-                Screen.Chat -> ChatScreen(context, hudEnabled)
+                Screen.Chat -> ChatScreen(viewModel, hudEnabled)
                 Screen.More -> MoreScreen { screen ->
                     currentScreen = when (screen) {
                         "Creations" -> Screen.Creations
@@ -293,7 +290,6 @@ fun MainScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BasicScreen(
-    session: OrtSession,
     onGenerateAudio: (String, String, Float, Boolean, () -> Unit) -> Unit,
     viewModel: MainViewModel
 ) {
@@ -311,7 +307,270 @@ fun BasicScreen(
     LaunchedEffect(selectedModel) {
         selectedModel?.let {
             val modelFile = java.io.File(context.filesDir, "models/${it.id}.task")
-            viewModel.reinitializeSession(modelFile.absolutePath)
+            viewModel.initializeLlm(modelFile.absolutePath)
+        }
+    }
+
+    val names = listOf(
+        "af",
+        "af_bella",
+        "af_nicole",
+        "af_sarah",
+        "af_sky",
+        "am_adam",
+        "am_michael",
+        "bf_emma",
+        "bf_isabella",
+        "bm_george",
+        "bm_lewis"
+    )
+    var expanded by remember { mutableStateOf(false) }
+    var modelExpanded by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        TextField(
+            value = text,
+            minLines = 3,
+            maxLines = aunch,
+import kotlinx.coroutines.withContext
+
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        DynamicColors.applyToActivitiesIfAvailable(this)
+    }
+}
+
+class MainActivity : ComponentActivity() {
+    private lateinit var phonemeConverter: PhonemeConverter
+    private val scope = MainScope()
+    private lateinit var userPreferencesRepository: UserPreferencesRepository
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        DebugLogger.initialize(this)
+        enableEdgeToEdge()
+        userPreferencesRepository = UserPreferencesRepository(this)
+
+        setContent {
+            KokoroTheme {
+                LaunchedEffect(Unit) {
+                    WindowCompat.setDecorFitsSystemWindows(window, false)
+                }
+
+                val viewModel: MainViewModel = viewModel { MainViewModel(this@MainActivity) }
+
+                MainScreen(
+                    phonemeConverter = phonemeConverter,
+                    onGenerateAudio = { text, style, speed, shouldSave, onComplete ->
+                        generateAudio(
+                            viewModel.getSession(),
+                            phonemeConverter,
+                            text,
+                            style,
+                            speed,
+                            this@MainActivity,
+                            scope,
+                            shouldSave,
+                            onComplete
+                        )
+                    },
+                    userPreferencesRepository = userPreferencesRepository
+                )
+            }
+        }
+
+        phonemeConverter = PhonemeConverter(this)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+    }
+}
+
+private fun generateAudio(
+    session: OrtSession,
+    phonemeConverter: PhonemeConverter,
+    text: String,
+    style: String,
+    speed: Float,
+    context: Context,
+    scope: CoroutineScope,
+    shouldSave: Boolean,
+    onComplete: () -> Unit
+) {
+    scope.launch(Dispatchers.IO) {
+        try {
+            val phonemes = phonemeConverter.phonemize(text)
+            DebugLogger.log("Phonemes: $phonemes")
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, "Phonemes: $phonemes", Toast.LENGTH_LONG).show()
+            }
+
+
+            val (audioData, sampleRate) = PerfHud.record("ONNX synth") {
+                createAudio(
+                    voice = style,
+                    phonemes = phonemes,
+                    speed = speed,
+                    context = context,
+                    session = session
+                )
+            }
+
+            playAudio(
+                audioData, scope,
+                onComplete = onComplete
+            )
+
+            if (shouldSave) {
+                saveAudio(audioData, context, style)
+            }
+        } catch (e: Exception) {
+            DebugLogger.log("Error: ${e.message}")
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, "Error: ${e.message}", Toast.LENGTH_LONG).show()
+            }
+        } finally {
+            withContext(Dispatchers.Main) {
+                onComplete()
+            }
+        }
+    }
+}
+
+sealed class Screen(val title: String) {
+    object Basic : Screen("Basic TTS")
+    object Mixer : Screen("Mixer")
+    object Book : Screen("Audio Book")
+    object Chat : Screen("Chat")
+    object More : Screen("More")
+    object Creations : Screen("Creations")
+    object Settings : Screen("Settings")
+    object About : Screen("About this app")
+    object Models : Screen("Models")
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MainScreen(
+    phonemeConverter: PhonemeConverter,
+    onGenerateAudio: (String, String, Float, Boolean, () -> Unit) -> Unit,
+    userPreferencesRepository: UserPreferencesRepository
+) {
+    var currentScreen by remember { mutableStateOf<Screen>(Screen.Basic) }
+    var hudEnabled by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    val viewModel: MainViewModel = viewModel { MainViewModel(context) }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(currentScreen.title) },
+                actions = {
+                    Switch(checked = hudEnabled, onCheckedChange = { checked -> hudEnabled = checked })
+                }
+            )
+        },
+        bottomBar = {
+            NavigationBar {
+                NavigationBarItem(
+                    icon = { Icon(Icons.Default.Home, contentDescription = "Basic") },
+                    label = { Text("Basic") },
+                    selected = currentScreen == Screen.Basic,
+                    onClick = { currentScreen = Screen.Basic }
+                )
+                NavigationBarItem(
+                    icon = { Icon(Icons.Default.Info, contentDescription = "Mixer") },
+                    label = { Text("Mixer") },
+                    selected = currentScreen == Screen.Mixer,
+                    onClick = { currentScreen = Screen.Mixer }
+                )
+                NavigationBarItem(
+                    icon = { Icon(Icons.Default.Info, contentDescription = "Book") },
+                    label = { Text("Book") },
+                    selected = currentScreen == Screen.Book,
+                    onClick = { currentScreen = Screen.Book }
+                )
+                NavigationBarItem(
+                    icon = { Icon(Icons.Default.Info, contentDescription = "Chat") },
+                    label = { Text("Chat") },
+                    selected = currentScreen == Screen.Chat,
+                    onClick = { currentScreen = Screen.Chat }
+                )
+                NavigationBarItem(
+                    icon = { Icon(Icons.Default.Info, contentDescription = "About") },
+                    label = { Text("About") },
+                    selected = currentScreen == Screen.About,
+                    onClick = { currentScreen = Screen.About }
+                )
+                 NavigationBarItem(
+                    icon = { Icon(Icons.Default.MoreHoriz, contentDescription = "More") },
+                    label = { Text("More") },
+                    selected = currentScreen == Screen.More,
+                    onClick = { currentScreen = Screen.More }
+                )
+            }
+        }
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding)) {
+            when (currentScreen) {
+                Screen.Basic -> BasicScreen(onGenerateAudio = onGenerateAudio, viewModel = viewModel)
+                Screen.Mixer -> MixerScreen(
+                    session = viewModel.getSession(),
+                    phonemeConverter = phonemeConverter,
+                    styleLoader = StyleLoader(context)
+                )
+                Screen.Book -> BookScreen(
+                    session = viewModel.getSession(),
+                    phonemeConverter = phonemeConverter
+                )
+                Screen.Chat -> ChatScreen(viewModel, hudEnabled)
+                Screen.More -> MoreScreen { screen ->
+                    currentScreen = when (screen) {
+                        "Creations" -> Screen.Creations
+                        "Settings" -> Screen.Settings
+                        "Models" -> Screen.Models
+                        else -> currentScreen
+                    }
+                }
+                Screen.Creations -> CreationsScreen()
+                Screen.Settings -> SettingsScreen()
+                Screen.About -> AboutScreen()
+                Screen.Models -> ModelsScreen(userPreferencesRepository)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BasicScreen(
+    onGenerateAudio: (String, String, Float, Boolean, () -> Unit) -> Unit,
+    viewModel: MainViewModel
+) {
+    val context = LocalContext.current
+    var text by remember { mutableStateOf("This is her warm heart, her warmest kokoro, unwavering love and comfort.") }
+    var style by remember { mutableStateOf(SettingsManager.getStyle(context)) }
+    var speed by remember { mutableFloatStateOf(SettingsManager.getSpeed(context)) }
+    var isProcessing by remember { mutableStateOf(false) }
+    var shouldSaveFile by remember { mutableStateOf(false) }
+
+    val modelManager = remember { com.example.kokoro82m.data.ModelManager(context) }
+    val models = remember { modelManager.models.filter { it.isDownloaded } }
+    var selectedModel by remember { mutableStateOf(models.firstOrNull()) }
+
+    LaunchedEffect(selectedModel) {
+        selectedModel?.let {
+            val modelFile = java.io.File(context.filesDir, "models/${it.id}.task")
+            viewModel.initializeLlm(modelFile.absolutePath)
         }
     }
 

--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Switch
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -205,7 +206,7 @@ fun MainScreen(
             CenterAlignedTopAppBar(
                 title = { Text(currentScreen.title) },
                 actions = {
-                    Switch(checked = hudEnabled, onCheckedChange = { hudEnabled = it })
+                    Switch(checked = hudEnabled, onCheckedChange = { checked -> hudEnabled = checked })
                 }
             )
         },

--- a/app/src/main/java/com/example/kokoro82m/data/DownloadWorker.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/DownloadWorker.kt
@@ -1,9 +1,9 @@
 package com.example.kokoro82m.data
 
 import android.content.Context
-import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.example.kokoro82m.utils.DebugLogger
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URL
@@ -13,6 +13,7 @@ class DownloadWorker(appContext: Context, workerParams: WorkerParameters) :
     CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result {
+        DebugLogger.initialize(applicationContext)
         val modelId = inputData.getString("model_id")
         val downloadUrl = inputData.getString("download_url")
         val hfToken = inputData.getString("hf_token")
@@ -28,21 +29,21 @@ class DownloadWorker(appContext: Context, workerParams: WorkerParameters) :
             }
             val destinationFile = File(modelDir, "$modelId.task")
 
-            Log.d("DownloadWorker", "Starting download for model '$modelId' from: $downloadUrl")
+            DebugLogger.log("DownloadWorker: Starting download for model '$modelId' from: $downloadUrl")
 
             val url = URL(downloadUrl)
             val connection = url.openConnection() as HttpsURLConnection
             hfToken?.let {
                 connection.setRequestProperty("Authorization", "Bearer $it")
-                Log.d("DownloadWorker", "Authorization header set for Hugging Face.")
+                DebugLogger.log("DownloadWorker: Authorization header set for Hugging Face.")
             }
             connection.connect()
 
             val responseCode = connection.responseCode
-            Log.d("DownloadWorker", "HTTP Response Code: $responseCode")
+            DebugLogger.log("DownloadWorker: HTTP Response Code: $responseCode")
 
             if (responseCode != HttpsURLConnection.HTTP_OK) {
-                Log.e("DownloadWorker", "HTTP error $responseCode for URL: $downloadUrl")
+                DebugLogger.log("DownloadWorker: HTTP error $responseCode for URL: $downloadUrl")
                 return Result.failure()
             }
 
@@ -58,10 +59,10 @@ class DownloadWorker(appContext: Context, workerParams: WorkerParameters) :
             outputStream.close()
             inputStream.close()
 
-            Log.d("DownloadWorker", "Model '$modelId' downloaded successfully to ${destinationFile.absolutePath}")
+            DebugLogger.log("DownloadWorker: Model '$modelId' downloaded successfully to ${destinationFile.absolutePath}")
             Result.success()
         } catch (e: Exception) {
-            Log.e("DownloadWorker", "Error downloading model '$modelId' from $downloadUrl", e)
+            DebugLogger.log("DownloadWorker: Error downloading model '$modelId' from $downloadUrl - ${e.message}")
             Result.failure()
         }
     }

--- a/app/src/main/java/com/example/kokoro82m/data/DownloadWorker.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/DownloadWorker.kt
@@ -1,0 +1,57 @@
+package com.example.kokoro82m.data
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import java.io.File
+import java.io.FileOutputStream
+import java.net.URL
+import javax.net.ssl.HttpsURLConnection
+
+class DownloadWorker(appContext: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        val modelId = inputData.getString("model_id")
+        val downloadUrl = inputData.getString("download_url")
+        val hfToken = inputData.getString("hf_token")
+
+        if (modelId.isNullOrEmpty() || downloadUrl.isNullOrEmpty()) {
+            return Result.failure()
+        }
+
+        return try {
+            val modelDir = File(applicationContext.filesDir, "models")
+            if (!modelDir.exists()) {
+                modelDir.mkdirs()
+            }
+            val destinationFile = File(modelDir, "$modelId.task")
+
+            val url = URL(downloadUrl)
+            val connection = url.openConnection() as HttpsURLConnection
+            hfToken?.let {
+                connection.setRequestProperty("Authorization", "Bearer $it")
+            }
+            connection.connect()
+
+            val inputStream = connection.getInputStream()
+            val outputStream = FileOutputStream(destinationFile)
+
+            val buffer = ByteArray(1024)
+            var len: Int
+            while (inputStream.read(buffer).also { len = it } != -1) {
+                outputStream.write(buffer, 0, len)
+            }
+
+            outputStream.close()
+            inputStream.close()
+
+            Log.d("DownloadWorker", "Model downloaded to ${destinationFile.absolutePath}")
+            Result.success()
+        } catch (e: Exception) {
+            Log.e("DownloadWorker", "Error downloading model", e)
+            Result.failure()
+        }
+    }
+}

--- a/app/src/main/java/com/example/kokoro82m/data/DownloadWorker.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/DownloadWorker.kt
@@ -28,12 +28,23 @@ class DownloadWorker(appContext: Context, workerParams: WorkerParameters) :
             }
             val destinationFile = File(modelDir, "$modelId.task")
 
+            Log.d("DownloadWorker", "Starting download for model '$modelId' from: $downloadUrl")
+
             val url = URL(downloadUrl)
             val connection = url.openConnection() as HttpsURLConnection
             hfToken?.let {
                 connection.setRequestProperty("Authorization", "Bearer $it")
+                Log.d("DownloadWorker", "Authorization header set for Hugging Face.")
             }
             connection.connect()
+
+            val responseCode = connection.responseCode
+            Log.d("DownloadWorker", "HTTP Response Code: $responseCode")
+
+            if (responseCode != HttpsURLConnection.HTTP_OK) {
+                Log.e("DownloadWorker", "HTTP error $responseCode for URL: $downloadUrl")
+                return Result.failure()
+            }
 
             val inputStream = connection.getInputStream()
             val outputStream = FileOutputStream(destinationFile)
@@ -47,10 +58,10 @@ class DownloadWorker(appContext: Context, workerParams: WorkerParameters) :
             outputStream.close()
             inputStream.close()
 
-            Log.d("DownloadWorker", "Model downloaded to ${destinationFile.absolutePath}")
+            Log.d("DownloadWorker", "Model '$modelId' downloaded successfully to ${destinationFile.absolutePath}")
             Result.success()
         } catch (e: Exception) {
-            Log.e("DownloadWorker", "Error downloading model", e)
+            Log.e("DownloadWorker", "Error downloading model '$modelId' from $downloadUrl", e)
             Result.failure()
         }
     }

--- a/app/src/main/java/com/example/kokoro82m/data/Model.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/Model.kt
@@ -1,0 +1,11 @@
+package com.example.kokoro82m.data
+
+data class Model(
+    val id: String,
+    val name: String,
+    val description: String,
+    val repo: String,
+    val downloadUrl: String,
+    val gated: Boolean,
+    var isDownloaded: Boolean = false
+)

--- a/app/src/main/java/com/example/kokoro82m/data/ModelDownloader.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/ModelDownloader.kt
@@ -4,22 +4,32 @@ import android.content.Context
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
-class ModelDownloader(private val context: Context) {
+class ModelDownloader(
+    private val context: Context,
+    private val userPreferencesRepository: UserPreferencesRepository
+) {
 
-    fun downloadModel(model: Model, token: String? = null) {
-        val dataBuilder = Data.Builder()
-            .putString("model_id", model.id)
-            .putString("download_url", model.downloadUrl)
+    fun downloadModel(model: Model) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val token = userPreferencesRepository.hfToken.first()
+            val dataBuilder = Data.Builder()
+                .putString("model_id", model.id)
+                .putString("download_url", model.downloadUrl)
 
-        token?.let {
-            dataBuilder.putString("hf_token", it)
+            token?.let {
+                dataBuilder.putString("hf_token", it)
+            }
+
+            val downloadWorkRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
+                .setInputData(dataBuilder.build())
+                .build()
+
+            WorkManager.getInstance(context).enqueue(downloadWorkRequest)
         }
-
-        val downloadWorkRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
-            .setInputData(dataBuilder.build())
-            .build()
-
-        WorkManager.getInstance(context).enqueue(downloadWorkRequest)
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/data/ModelDownloader.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/ModelDownloader.kt
@@ -1,0 +1,25 @@
+package com.example.kokoro82m.data
+
+import android.content.Context
+import androidx.work.Data
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+
+class ModelDownloader(private val context: Context) {
+
+    fun downloadModel(model: Model, token: String? = null) {
+        val dataBuilder = Data.Builder()
+            .putString("model_id", model.id)
+            .putString("download_url", model.downloadUrl)
+
+        token?.let {
+            dataBuilder.putString("hf_token", it)
+        }
+
+        val downloadWorkRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
+            .setInputData(dataBuilder.build())
+            .build()
+
+        WorkManager.getInstance(context).enqueue(downloadWorkRequest)
+    }
+}

--- a/app/src/main/java/com/example/kokoro82m/data/ModelManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/ModelManager.kt
@@ -1,0 +1,39 @@
+package com.example.kokoro82m.data
+
+import android.content.Context
+import com.example.kokoro82m.R
+import org.json.JSONObject
+
+class ModelManager(private val context: Context) {
+
+    val models: List<Model> by lazy {
+        loadModelsFromAllowlist()
+    }
+
+    private fun loadModelsFromAllowlist(): List<Model> {
+        val modelList = mutableListOf<Model>()
+        val jsonString = context.resources.openRawResource(R.raw.model_allowlist).bufferedReader().use { it.readText() }
+        val json = JSONObject(jsonString)
+        val keys = json.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            val modelJson = json.getJSONObject(key)
+            val model = Model(
+                id = key,
+                name = modelJson.getString("name"),
+                description = modelJson.getString("description"),
+                repo = modelJson.getString("repo"),
+                downloadUrl = modelJson.getString("downloadUrl"),
+                gated = modelJson.optBoolean("gated", false)
+            )
+            val modelFile = java.io.File(context.filesDir, "models/${model.id}.task")
+            model.isDownloaded = modelFile.exists()
+            modelList.add(model)
+        }
+        return modelList
+    }
+
+    fun getModel(id: String): Model? {
+        return models.find { it.id == id }
+    }
+}

--- a/app/src/main/java/com/example/kokoro82m/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/UserPreferencesRepository.kt
@@ -1,0 +1,28 @@
+package com.example.kokoro82m.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+
+class UserPreferencesRepository(private val context: Context) {
+
+    private val hfTokenKey = stringPreferencesKey("hf_token")
+
+    val hfToken: Flow<String?> = context.dataStore.data
+        .map { preferences ->
+            preferences[hfTokenKey]
+        }
+
+    suspend fun saveHfToken(token: String) {
+        context.dataStore.edit { settings ->
+            settings[hfTokenKey] = token
+        }
+    }
+}

--- a/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
@@ -14,28 +14,41 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.example.kokoro82m.data.Model
 import com.example.kokoro82m.data.ModelDownloader
 import com.example.kokoro82m.data.ModelManager
+import com.example.kokoro82m.data.UserPreferencesRepository
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ModelsScreen() {
+fun ModelsScreen(userPreferencesRepository: UserPreferencesRepository) {
     val context = LocalContext.current
     val modelManager = remember { ModelManager(context) }
-    val modelDownloader = remember { ModelDownloader(context) }
+    val modelDownloader = remember { ModelDownloader(context, userPreferencesRepository) }
     val models = modelManager.models
+    val scope = rememberCoroutineScope()
 
     var showDialog by remember { mutableStateOf(false) }
     var selectedModel by remember { mutableStateOf<Model?>(null) }
     var hfToken by remember { mutableStateOf("") }
+
+    LaunchedEffect(Unit) {
+        userPreferencesRepository.hfToken.collect { token ->
+            if (token != null) {
+                hfToken = token
+            }
+        }
+    }
 
     if (showDialog) {
         AlertDialog(
@@ -46,7 +59,12 @@ fun ModelsScreen() {
                     Text("This model is gated. Please enter your Hugging Face token to download.")
                     TextField(
                         value = hfToken,
-                        onValueChange = { hfToken = it },
+                        onValueChange = {
+                            hfToken = it
+                            scope.launch {
+                                userPreferencesRepository.saveHfToken(it)
+                            }
+                        },
                         label = { Text("Token") }
                     )
                 }
@@ -55,7 +73,7 @@ fun ModelsScreen() {
                 Button(
                     onClick = {
                         selectedModel?.let {
-                            modelDownloader.downloadModel(it, hfToken)
+                            modelDownloader.downloadModel(it)
                         }
                         showDialog = false
                     }

--- a/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
@@ -1,0 +1,106 @@
+package com.example.kokoro82m.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.example.kokoro82m.data.Model
+import com.example.kokoro82m.data.ModelDownloader
+import com.example.kokoro82m.data.ModelManager
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ModelsScreen() {
+    val context = LocalContext.current
+    val modelManager = remember { ModelManager(context) }
+    val modelDownloader = remember { ModelDownloader(context) }
+    val models = modelManager.models
+
+    var showDialog by remember { mutableStateOf(false) }
+    var selectedModel by remember { mutableStateOf<Model?>(null) }
+    var hfToken by remember { mutableStateOf("") }
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text("Hugging Face Token") },
+            text = {
+                Column {
+                    Text("This model is gated. Please enter your Hugging Face token to download.")
+                    TextField(
+                        value = hfToken,
+                        onValueChange = { hfToken = it },
+                        label = { Text("Token") }
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        selectedModel?.let {
+                            modelDownloader.downloadModel(it, hfToken)
+                        }
+                        showDialog = false
+                    }
+                ) {
+                    Text("Download")
+                }
+            },
+            dismissButton = {
+                Button(onClick = { showDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        items(models) { model ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column {
+                    Text(text = model.name, style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+                    Text(text = model.description, style = androidx.compose.material3.MaterialTheme.typography.bodyMedium)
+                }
+                if (model.isDownloaded) {
+                    Text("Downloaded")
+                } else {
+                    Button(onClick = {
+                        if (model.gated) {
+                            selectedModel = model
+                            showDialog = true
+                        } else {
+                            modelDownloader.downloadModel(model)
+                        }
+                    }) {
+                        Text("Download")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/kokoro82m/screens/MoreScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/MoreScreen.kt
@@ -31,5 +31,11 @@ fun MoreScreen(onNavigate: (String) -> Unit) {
         ) {
             Text("Settings")
         }
+        Button(
+            onClick = { onNavigate("Models") },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Models")
+        }
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/utils/LlmInferenceManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/LlmInferenceManager.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.kokoro82m.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.util.Log
+import com.google.mediapipe.tasks.genai.llminference.LlmInference
+import com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession
+import java.io.File
+
+private const val TAG = "LlmInferenceManager"
+
+typealias ResultListener = (partialResult: String, done: Boolean) -> Unit
+
+object LlmInferenceManager {
+    private var llmInference: LlmInference? = null
+    private var session: LlmInferenceSession? = null
+
+    fun initialize(context: Context, modelPath: String) {
+        if (llmInference != null) {
+            return
+        }
+        val options = LlmInference.LlmInferenceOptions.builder()
+            .setModelPath(modelPath)
+            .build()
+        llmInference = LlmInference.createFromOptions(context, options)
+        session = llmInference?.createSession()
+    }
+
+    fun generateResponse(prompt: String, resultListener: ResultListener) {
+        session?.generateResponseAsync(prompt, resultListener)
+    }
+
+    fun release() {
+        session?.close()
+        session = null
+        llmInference?.close()
+        llmInference = null
+    }
+}

--- a/app/src/main/java/com/example/kokoro82m/utils/OnnxRuntimeManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/OnnxRuntimeManager.kt
@@ -8,9 +8,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.kokoro82m.R
 import kotlinx.coroutines.launch
-import java.io.InputStream
+import java.io.File
 
-class MainViewModel(context: Context) : ViewModel() {
+class MainViewModel(private val context: Context) : ViewModel() {
     init {
         viewModelScope.launch {
             OnnxRuntimeManager.initialize(context.applicationContext)
@@ -18,6 +18,12 @@ class MainViewModel(context: Context) : ViewModel() {
     }
 
     fun getSession() = OnnxRuntimeManager.getSession()
+
+    fun reinitializeSession(modelPath: String) {
+        viewModelScope.launch {
+            OnnxRuntimeManager.reinitialize(context, modelPath)
+        }
+    }
 }
 
 object OnnxRuntimeManager {
@@ -25,11 +31,21 @@ object OnnxRuntimeManager {
     private var session: OrtSession? = null
 
     @Synchronized
-    fun initialize(context: Context) {
+    fun initialize(context: Context, modelPath: String? = null) {
         if (environment == null) {
             environment = OrtEnvironment.getEnvironment()
-            session = createSession(context)
         }
+        session = if (modelPath != null) {
+            createSession(modelPath)
+        } else {
+            createSession(context)
+        }
+    }
+
+    @Synchronized
+    fun reinitialize(context: Context, modelPath: String) {
+        session?.close()
+        initialize(context, modelPath)
     }
 
     private fun createSession(context: Context): OrtSession {
@@ -44,5 +60,17 @@ object OnnxRuntimeManager {
         }
     }
 
+    private fun createSession(modelPath: String): OrtSession {
+        val options = SessionOptions().apply {
+            addConfigEntry("nnapi.flags", "USE_FP16")
+            addConfigEntry("nnapi.use_gpu", "true")
+            addConfigEntry("nnapi.gpu_precision_loss_allowed", "true")
+        }
+        val modelBytes = File(modelPath).readBytes()
+        return environment!!.createSession(modelBytes, options)
+    }
+
+
     fun getSession() = requireNotNull(session) { "ONNX Session not initialized" }
 }
+

--- a/app/src/main/java/com/example/kokoro82m/utils/OnnxRuntimeManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/OnnxRuntimeManager.kt
@@ -4,48 +4,18 @@ import ai.onnxruntime.OrtEnvironment
 import ai.onnxruntime.OrtSession
 import ai.onnxruntime.OrtSession.SessionOptions
 import android.content.Context
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.example.kokoro82m.R
-import kotlinx.coroutines.launch
-import java.io.File
-
-class MainViewModel(private val context: Context) : ViewModel() {
-    init {
-        viewModelScope.launch {
-            OnnxRuntimeManager.initialize(context.applicationContext)
-        }
-    }
-
-    fun getSession() = OnnxRuntimeManager.getSession()
-
-    fun reinitializeSession(modelPath: String) {
-        viewModelScope.launch {
-            OnnxRuntimeManager.reinitialize(context, modelPath)
-        }
-    }
-}
 
 object OnnxRuntimeManager {
     private var environment: OrtEnvironment? = null
     private var session: OrtSession? = null
 
     @Synchronized
-    fun initialize(context: Context, modelPath: String? = null) {
+    fun initialize(context: Context) {
         if (environment == null) {
             environment = OrtEnvironment.getEnvironment()
         }
-        session = if (modelPath != null) {
-            createSession(modelPath)
-        } else {
-            createSession(context)
-        }
-    }
-
-    @Synchronized
-    fun reinitialize(context: Context, modelPath: String) {
-        session?.close()
-        initialize(context, modelPath)
+        session = createSession(context)
     }
 
     private fun createSession(context: Context): OrtSession {
@@ -59,17 +29,6 @@ object OnnxRuntimeManager {
             environment!!.createSession(stream.readBytes(), options)
         }
     }
-
-    private fun createSession(modelPath: String): OrtSession {
-        val options = SessionOptions().apply {
-            addConfigEntry("nnapi.flags", "USE_FP16")
-            addConfigEntry("nnapi.use_gpu", "true")
-            addConfigEntry("nnapi.gpu_precision_loss_allowed", "true")
-        }
-        val modelBytes = File(modelPath).readBytes()
-        return environment!!.createSession(modelBytes, options)
-    }
-
 
     fun getSession() = requireNotNull(session) { "ONNX Session not initialized" }
 }

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/MainViewModel.kt
@@ -1,0 +1,49 @@
+package com.example.kokoro82m.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.kokoro82m.utils.LlmInferenceManager
+import com.example.kokoro82m.utils.OnnxRuntimeManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class MainViewModel(private val context: Context) : ViewModel() {
+    private val _chatMessages = MutableStateFlow(listOf<String>())
+    val chatMessages: StateFlow<List<String>> = _chatMessages
+
+    private val _isLlmInitialized = MutableStateFlow(false)
+    val isLlmInitialized: StateFlow<Boolean> = _isLlmInitialized
+
+    init {
+        viewModelScope.launch {
+            OnnxRuntimeManager.initialize(context.applicationContext)
+        }
+    }
+
+    fun getSession() = OnnxRuntimeManager.getSession()
+
+    fun initializeLlm(modelPath: String) {
+        viewModelScope.launch {
+            LlmInferenceManager.initialize(context, modelPath)
+            _isLlmInitialized.value = true
+        }
+    }
+
+    fun sendChatMessage(prompt: String) {
+        viewModelScope.launch {
+            _chatMessages.value += "> $prompt"
+            var currentResponse = ""
+            LlmInferenceManager.generateResponse(prompt) { partialResult, done ->
+                currentResponse += partialResult
+                _chatMessages.value = _chatMessages.value.dropLast(1) + ("> $prompt\n$currentResponse")
+            }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        LlmInferenceManager.release()
+    }
+}

--- a/app/src/main/res/raw/model_allowlist.json
+++ b/app/src/main/res/raw/model_allowlist.json
@@ -3,7 +3,7 @@
     "name": "Gemma 3n IT 4B",
     "description": "Gemma 3n Instruct 4B parameter model",
     "repo": "google/gemma-3n-E4B-it-int4",
-    "downloadUrl": "https://huggingface.co/google/gemma-3n-E4B-it-int4/resolve/main/model.task",
+    "downloadUrl": "https://huggingface.co/google/gemma-3n-E4B-it-litert-preview/resolve/main/gemma-3n-E4B-it-int4.task",
     "gated": true
   }
 }

--- a/app/src/main/res/raw/model_allowlist.json
+++ b/app/src/main/res/raw/model_allowlist.json
@@ -1,0 +1,9 @@
+{
+  "gemma-3n-E4B-it-int4": {
+    "name": "Gemma 3n IT 4B",
+    "description": "Gemma 3n Instruct 4B parameter model",
+    "repo": "google/gemma-3n-E4B-it-int4",
+    "downloadUrl": "https://huggingface.co/google/gemma-3n-E4B-it-int4/resolve/main/model.task",
+    "gated": true
+  }
+}


### PR DESCRIPTION
## Summary
- add MediaPipe LiteRT/Tasks dependencies
- implement model download & inference utilities
- integrate performance HUD and chat screen
- instrument ONNX synth path with perf logging

## Testing
- `gradle :app:dependencies --configuration debugRuntimeClasspath`
- `gradle clean assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d3c3d73188331b9b114e0cf191d00