### PR TITLE
Add audio line pregeneration

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/ChatActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/ChatActivity.kt
@@ -1,6 +1,8 @@
 package com.example.kokoro82m
 
+import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -9,6 +11,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.example.kokoro.chat.ChatScreen
 import com.example.kokoro.chat.ChatViewModel
 import com.example.kokoro.chat.LlmInference
+import com.example.kokoro82m.data.ModelManager
 import java.io.File
 
 class ChatActivity : ComponentActivity() {
@@ -16,6 +19,24 @@ class ChatActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         val modelId = "gemma-3n-E4B-it-int4"
+        val modelManager = ModelManager(applicationContext)
+        val model = modelManager.getModel(modelId)
+
+        if (model == null || !model.isDownloaded) {
+            Toast.makeText(
+                this,
+                "Chat model not downloaded. Redirecting to model page.",
+                Toast.LENGTH_LONG
+            ).show()
+            startActivity(
+                Intent(this, MainActivity::class.java).apply {
+                    putExtra(EXTRA_START_SCREEN, "Models")
+                }
+            )
+            finish()
+            return
+        }
+
         val modelFile = File(filesDir, "models/$modelId.task")
 
         val llmInference = LlmInference(

--- a/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
@@ -1,6 +1,7 @@
 package com.example.kokoro82m
 
 import KokoroTheme
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -27,9 +28,14 @@ class ChatTtsActivity : ComponentActivity() {
         if (chatModel == null || !chatModel.isDownloaded) {
             Toast.makeText(
                 this,
-                "Chat model not downloaded. Please go to More > Models to download it.",
+                "Chat model not downloaded. Redirecting to model page.",
                 Toast.LENGTH_LONG
             ).show()
+            startActivity(
+                Intent(this, MainActivity::class.java).apply {
+                    putExtra(EXTRA_START_SCREEN, "Models")
+                }
+            )
             finish()
             return
         }

--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -77,6 +77,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+const val EXTRA_START_SCREEN = "start_screen"
+
 class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
@@ -94,6 +96,8 @@ class MainActivity : ComponentActivity() {
         DebugLogger.initialize(this)
         enableEdgeToEdge()
         userPreferencesRepository = UserPreferencesRepository(this)
+
+        val startScreen = screenFromString(intent.getStringExtra(EXTRA_START_SCREEN))
 
         setContent {
             KokoroTheme {
@@ -120,7 +124,8 @@ class MainActivity : ComponentActivity() {
                             onComplete
                         )
                     },
-                    userPreferencesRepository = userPreferencesRepository
+                    userPreferencesRepository = userPreferencesRepository,
+                    initialScreen = startScreen
                 )
             }
         }
@@ -185,6 +190,20 @@ private fun generateAudio(
     }
 }
 
+private fun screenFromString(name: String?): Screen = when (name) {
+    "Basic" -> Screen.Basic
+    "Mixer" -> Screen.Mixer
+    "Book" -> Screen.Book
+    "Chat" -> Screen.Chat
+    "ChatTts" -> Screen.ChatTts
+    "More" -> Screen.More
+    "Creations" -> Screen.Creations
+    "Settings" -> Screen.Settings
+    "About" -> Screen.About
+    "Models" -> Screen.Models
+    else -> Screen.Basic
+}
+
 sealed class Screen(val title: String) {
     object Basic : Screen("Basic TTS")
     object Mixer : Screen("Mixer")
@@ -204,9 +223,10 @@ fun MainScreen(
     session: OrtSession,
     phonemeConverter: PhonemeConverter,
     onGenerateAudio: (String, String, Float, Boolean, () -> Unit) -> Unit,
-    userPreferencesRepository: UserPreferencesRepository
+    userPreferencesRepository: UserPreferencesRepository,
+    initialScreen: Screen = Screen.Basic
 ) {
-    var currentScreen by remember { mutableStateOf<Screen>(Screen.Basic) }
+    var currentScreen by remember { mutableStateOf(initialScreen) }
     var hudEnabled by remember { mutableStateOf(false) }
     val context = LocalContext.current
     val viewModel: MainViewModel = viewModel { MainViewModel(context) }

--- a/app/src/main/java/com/example/kokoro82m/data/Model.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/Model.kt
@@ -7,5 +7,6 @@ data class Model(
     val repo: String,
     val downloadUrl: String,
     val gated: Boolean,
-    var isDownloaded: Boolean = false
+    var isDownloaded: Boolean = false,
+    var hasPartial: Boolean = false,
 )

--- a/app/src/main/java/com/example/kokoro82m/data/ModelDownloader.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/ModelDownloader.kt
@@ -23,23 +23,38 @@ class ModelDownloader(
     fun downloadModel(model: Model) {
         scope.launch {
             val token = userPreferencesRepository.hfToken.first()
+            val modelDir = File(context.filesDir, "models")
+            if (!modelDir.exists()) modelDir.mkdirs()
+            val finalFile = File(modelDir, "${model.id}.task")
+            val tempFile = File(modelDir, "${model.id}.task.part")
+
+            if (finalFile.exists()) {
+                model.isDownloaded = true
+                model.hasPartial = false
+                return@launch
+            }
+
+            val existingSize = if (tempFile.exists()) tempFile.length() else 0L
+            model.hasPartial = existingSize > 0
+
             try {
                 val url = URL(model.downloadUrl)
                 val connection = url.openConnection() as HttpsURLConnection
                 token?.let { connection.setRequestProperty("Authorization", "Bearer $it") }
+                if (existingSize > 0) {
+                    connection.setRequestProperty("Range", "bytes=$existingSize-")
+                }
                 connection.connect()
 
-                val total = connection.contentLength
+                val contentLength = connection.getHeaderFieldInt("Content-Length", -1)
+                val total = if (contentLength > 0) contentLength + existingSize else -1
                 val input = connection.inputStream
 
-                val modelDir = File(context.filesDir, "models")
-                if (!modelDir.exists()) modelDir.mkdirs()
-                val destFile = File(modelDir, "${model.id}.task")
-                val output = FileOutputStream(destFile)
+                val output = FileOutputStream(tempFile, existingSize > 0)
 
                 val buffer = ByteArray(1024)
                 var bytesRead: Int
-                var downloaded = 0
+                var downloaded = existingSize
                 while (input.read(buffer).also { bytesRead = it } != -1) {
                     output.write(buffer, 0, bytesRead)
                     downloaded += bytesRead
@@ -51,8 +66,12 @@ class ModelDownloader(
 
                 output.close()
                 input.close()
+
+                tempFile.renameTo(finalFile)
                 model.isDownloaded = true
+                model.hasPartial = false
             } catch (_: Exception) {
+                model.hasPartial = tempFile.exists()
             } finally {
                 _progress.value = _progress.value.toMutableMap().apply { remove(model.id) }
             }

--- a/app/src/main/java/com/example/kokoro82m/data/ModelDownloader.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/ModelDownloader.kt
@@ -1,35 +1,61 @@
 package com.example.kokoro82m.data
 
 import android.content.Context
-import androidx.work.Data
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.WorkManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import java.io.File
+import java.io.FileOutputStream
+import java.net.URL
+import javax.net.ssl.HttpsURLConnection
 
 class ModelDownloader(
     private val context: Context,
-    private val userPreferencesRepository: UserPreferencesRepository
+    private val userPreferencesRepository: UserPreferencesRepository,
 ) {
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private val _progress = MutableStateFlow<Map<String, Float>>(emptyMap())
+    val progress: StateFlow<Map<String, Float>> = _progress
 
     fun downloadModel(model: Model) {
-        CoroutineScope(Dispatchers.IO).launch {
+        scope.launch {
             val token = userPreferencesRepository.hfToken.first()
-            val dataBuilder = Data.Builder()
-                .putString("model_id", model.id)
-                .putString("download_url", model.downloadUrl)
+            try {
+                val url = URL(model.downloadUrl)
+                val connection = url.openConnection() as HttpsURLConnection
+                token?.let { connection.setRequestProperty("Authorization", "Bearer $it") }
+                connection.connect()
 
-            token?.let {
-                dataBuilder.putString("hf_token", it)
+                val total = connection.contentLength
+                val input = connection.inputStream
+
+                val modelDir = File(context.filesDir, "models")
+                if (!modelDir.exists()) modelDir.mkdirs()
+                val destFile = File(modelDir, "${model.id}.task")
+                val output = FileOutputStream(destFile)
+
+                val buffer = ByteArray(1024)
+                var bytesRead: Int
+                var downloaded = 0
+                while (input.read(buffer).also { bytesRead = it } != -1) {
+                    output.write(buffer, 0, bytesRead)
+                    downloaded += bytesRead
+                    if (total > 0) {
+                        val p = downloaded.toFloat() / total
+                        _progress.value = _progress.value.toMutableMap().apply { put(model.id, p) }
+                    }
+                }
+
+                output.close()
+                input.close()
+                model.isDownloaded = true
+            } catch (_: Exception) {
+            } finally {
+                _progress.value = _progress.value.toMutableMap().apply { remove(model.id) }
             }
-
-            val downloadWorkRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
-                .setInputData(dataBuilder.build())
-                .build()
-
-            WorkManager.getInstance(context).enqueue(downloadWorkRequest)
         }
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/data/ModelManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/ModelManager.kt
@@ -26,8 +26,11 @@ class ModelManager(private val context: Context) {
                 downloadUrl = modelJson.getString("downloadUrl"),
                 gated = modelJson.optBoolean("gated", false)
             )
-            val modelFile = java.io.File(context.filesDir, "models/${model.id}.task")
+            val modelDir = java.io.File(context.filesDir, "models")
+            val modelFile = java.io.File(modelDir, "${model.id}.task")
+            val partialFile = java.io.File(modelDir, "${model.id}.task.part")
             model.isDownloaded = modelFile.exists()
+            model.hasPartial = !model.isDownloaded && partialFile.exists()
             modelList.add(model)
         }
         return modelList
@@ -35,5 +38,13 @@ class ModelManager(private val context: Context) {
 
     fun getModel(id: String): Model? {
         return models.find { it.id == id }
+    }
+
+    fun deleteModel(model: Model) {
+        val modelDir = java.io.File(context.filesDir, "models")
+        java.io.File(modelDir, "${model.id}.task").delete()
+        java.io.File(modelDir, "${model.id}.task.part").delete()
+        model.isDownloaded = false
+        model.hasPartial = false
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.kokoro82m.R
 import com.example.kokoro82m.utils.*
+import com.example.kokoro82m.ui.components.ProgressDialog
 import com.example.kokoro82m.viewmodel.BookViewModel
 import kotlinx.coroutines.launch
 
@@ -54,6 +55,8 @@ fun BookScreen(
     var speed by remember { mutableFloatStateOf(SettingsManager.getSpeed(context)) }
     var debugMessage by remember { mutableStateOf<String?>(null) }
     var isProcessing by remember { mutableStateOf(false) }
+    var isPregenerating by remember { mutableStateOf(false) }
+    var preGenProgress by remember { mutableFloatStateOf(0f) }
 
     var showSettings by remember { mutableStateOf(true) }
 
@@ -294,6 +297,42 @@ fun BookScreen(
                 ) {
                     Text("Save Project")
                 }
+                Button(
+                    onClick = {
+                        if (bookUri != null) {
+                            isPregenerating = true
+                            preGenProgress = 0f
+                            scope.launch {
+                                try {
+                                    val project = Project(
+                                        uri = bookUri!!.toString(),
+                                        styles = selectedStyles,
+                                        weights = weights,
+                                        mode = interpolationMode,
+                                        speed = speed,
+                                        bookmark = bookmark
+                                    )
+                                    preGenerateBook(
+                                        context = context,
+                                        session = session,
+                                        phonemeConverter = phonemeConverter,
+                                        styleLoader = styleLoader,
+                                        project = project,
+                                        lines = lines,
+                                        onProgress = { preGenProgress = it }
+                                    )
+                                } catch (e: Exception) {
+                                    debugMessage = e.localizedMessage
+                                } finally {
+                                    isPregenerating = false
+                                }
+                            }
+                        }
+                    },
+                    enabled = !isPregenerating && lines.isNotEmpty() && bookUri != null
+                ) {
+                    Text(if (isPregenerating) "Pre-generating..." else "Pregenerate")
+                }
             }
         }
 
@@ -346,6 +385,13 @@ fun BookScreen(
                 Text(logs, modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_medium)))
             }
         }
+    }
+
+    if (isPregenerating) {
+        ProgressDialog(
+            message = "Pre-generating ${(preGenProgress * 100).toInt()}%",
+            progress = preGenProgress
+        )
     }
 }
 

--- a/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import com.example.kokoro82m.ui.components.ProgressDialog
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -142,18 +143,10 @@ fun ModelsScreen(userPreferencesRepository: UserPreferencesRepository) {
             val entry = progressMap.entries.first()
             val downloading = models.find { it.id == entry.key }
             val progress = entry.value
-            Column(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .fillMaxWidth()
-                    .padding(16.dp)
-            ) {
-                LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())
-                Text(
-                    text = "Downloading ${downloading?.name ?: "model"} ${(progress * 100).toInt()}%",
-                    modifier = Modifier.padding(top = 8.dp)
-                )
-            }
+            ProgressDialog(
+                message = "Downloading ${downloading?.name ?: "model"} ${(progress * 100).toInt()}%",
+                progress = progress,
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
@@ -109,19 +109,27 @@ fun ModelsScreen(userPreferencesRepository: UserPreferencesRepository) {
                 }
                 val progress = progressMap[model.id]
                 if (model.isDownloaded) {
-                    Text("Downloaded")
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text("Downloaded")
+                        Button(onClick = { modelManager.deleteModel(model) }) { Text("Delete") }
+                    }
                 } else if (progress != null) {
                     LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())
                 } else {
-                    Button(onClick = {
-                        if (model.gated) {
-                            selectedModel = model
-                            showDialog = true
-                        } else {
-                            modelDownloader.downloadModel(model)
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Button(onClick = {
+                            if (model.gated) {
+                                selectedModel = model
+                                showDialog = true
+                            } else {
+                                modelDownloader.downloadModel(model)
+                            }
+                        }) {
+                            Text(if (model.hasPartial) "Resume" else "Download")
                         }
-                    }) {
-                        Text("Download")
+                        if (model.hasPartial) {
+                            Button(onClick = { modelManager.deleteModel(model) }) { Text("Delete") }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
@@ -108,31 +108,34 @@ fun ModelsScreen(userPreferencesRepository: UserPreferencesRepository) {
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     Column {
-                    Text(text = model.name, style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
-                    Text(text = model.description, style = androidx.compose.material3.MaterialTheme.typography.bodyMedium)
-                }
-                val progress = progressMap[model.id]
-                if (model.isDownloaded) {
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Text("Downloaded")
-                        Button(onClick = { modelManager.deleteModel(model) }) { Text("Delete") }
+                        Text(text = model.name, style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+                        Text(text = model.description, style = androidx.compose.material3.MaterialTheme.typography.bodyMedium)
                     }
-                } else if (progress != null) {
-                    LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())
-                } else {
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Button(onClick = {
-                            if (model.gated) {
-                                selectedModel = model
-                                showDialog = true
-                            } else {
-                                modelDownloader.downloadModel(model)
+                    Column {
+                        val progress = progressMap[model.id]
+                        if (model.isDownloaded) {
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Text("Downloaded")
+                                Button(onClick = { modelManager.deleteModel(model) }) { Text("Delete") }
                             }
-                        }) {
-                            Text(if (model.hasPartial) "Resume" else "Download")
-                        }
-                        if (model.hasPartial) {
-                            Button(onClick = { modelManager.deleteModel(model) }) { Text("Delete") }
+                        } else if (progress != null) {
+                            LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())
+                        } else {
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Button(onClick = {
+                                    if (model.gated) {
+                                        selectedModel = model
+                                        showDialog = true
+                                    } else {
+                                        modelDownloader.downloadModel(model)
+                                    }
+                                }) {
+                                    Text(if (model.hasPartial) "Resume" else "Download")
+                                }
+                                if (model.hasPartial) {
+                                    Button(onClick = { modelManager.deleteModel(model) }) { Text("Delete") }
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
@@ -11,15 +11,17 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -36,6 +38,7 @@ fun ModelsScreen(userPreferencesRepository: UserPreferencesRepository) {
     val modelManager = remember { ModelManager(context) }
     val modelDownloader = remember { ModelDownloader(context, userPreferencesRepository) }
     val models = modelManager.models
+    val progressMap by modelDownloader.progress.collectAsState()
     val scope = rememberCoroutineScope()
 
     var showDialog by remember { mutableStateOf(false) }
@@ -104,8 +107,11 @@ fun ModelsScreen(userPreferencesRepository: UserPreferencesRepository) {
                     Text(text = model.name, style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
                     Text(text = model.description, style = androidx.compose.material3.MaterialTheme.typography.bodyMedium)
                 }
+                val progress = progressMap[model.id]
                 if (model.isDownloaded) {
                     Text("Downloaded")
+                } else if (progress != null) {
+                    LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())
                 } else {
                     Button(onClick = {
                         if (model.gated) {

--- a/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
@@ -1,6 +1,7 @@
 package com.example.kokoro82m.screens
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,6 +25,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import com.example.kokoro82m.data.Model
 import com.example.kokoro82m.data.ModelDownloader
@@ -92,18 +94,19 @@ fun ModelsScreen(userPreferencesRepository: UserPreferencesRepository) {
         )
     }
 
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        items(models) { model ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Column {
+    Box(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            items(models) { model ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column {
                     Text(text = model.name, style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
                     Text(text = model.description, style = androidx.compose.material3.MaterialTheme.typography.bodyMedium)
                 }
@@ -132,6 +135,24 @@ fun ModelsScreen(userPreferencesRepository: UserPreferencesRepository) {
                         }
                     }
                 }
+            }
+        }
+
+        if (progressMap.isNotEmpty()) {
+            val entry = progressMap.entries.first()
+            val downloading = models.find { it.id == entry.key }
+            val progress = entry.value
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())
+                Text(
+                    text = "Downloading ${downloading?.name ?: "model"} ${(progress * 100).toInt()}%",
+                    modifier = Modifier.padding(top = 8.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/kokoro82m/ui/components/ProgressDialog.kt
+++ b/app/src/main/java/com/example/kokoro82m/ui/components/ProgressDialog.kt
@@ -1,0 +1,31 @@
+package com.example.kokoro82m.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ProgressDialog(message: String, progress: Float?, onDismiss: (() -> Unit)? = null) {
+    AlertDialog(
+        onDismissRequest = { onDismiss?.invoke() },
+        confirmButton = {},
+        text = {
+            Column {
+                Text(message)
+                Spacer(modifier = Modifier.height(8.dp))
+                if (progress != null) {
+                    LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())
+                } else {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/kokoro82m/utils/AudioPreGenerator.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/AudioPreGenerator.kt
@@ -1,0 +1,45 @@
+package com.example.kokoro82m.utils
+
+import ai.onnxruntime.OrtSession
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+suspend fun preGenerateBook(
+    context: Context,
+    session: OrtSession,
+    phonemeConverter: PhonemeConverter,
+    styleLoader: StyleLoader,
+    project: Project,
+    lines: List<String>,
+    onProgress: (Float) -> Unit = {}
+) = withContext(Dispatchers.IO) {
+    DebugLogger.log("Pre-generate start for ${project.uri}")
+    val baseDir = project.audioPath?.let { File(it) }
+        ?: File(context.filesDir, "pregenerated/${project.uri.hashCode()}").also { it.mkdirs() }
+
+    if (project.audioPath == null) {
+        DatabaseManager.setProject(context, project.copy(audioPath = baseDir.absolutePath))
+    }
+
+    val mixed = mixStyles(styleLoader, project.styles, project.weights, project.mode)
+
+    for ((index, line) in lines.withIndex()) {
+        if (DatabaseManager.getAudioLine(context, project.uri, index) != null) continue
+        DebugLogger.log("Generating line $index for ${project.uri}")
+        val phonemes = phonemeConverter.phonemize(line)
+        val (audio, _) = createAudioFromStyleVector(
+            phonemes = phonemes,
+            voice = mixed,
+            speed = project.speed,
+            session = session,
+        )
+        val file = File(baseDir, "$index.wav")
+        saveAudioInternal(audio, file)
+        DatabaseManager.setAudioLine(context, project.uri, index, file.absolutePath)
+        val progress = (index + 1).toFloat() / lines.size
+        onProgress(progress)
+    }
+    DebugLogger.log("Pre-generate finished for ${project.uri}")
+}

--- a/app/src/main/java/com/example/kokoro82m/utils/DatabaseHelper.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/DatabaseHelper.kt
@@ -8,7 +8,7 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME
 
     companion object {
         private const val DATABASE_NAME = "kokoro.db"
-        private const val DATABASE_VERSION = 1
+        private const val DATABASE_VERSION = 2
         const val TABLE_PROJECTS = "projects"
         const val COLUMN_ID = "_id"
         const val COLUMN_URI = "uri"
@@ -18,6 +18,11 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME
         const val COLUMN_SPEED = "speed"
         const val COLUMN_BOOKMARK_LINE = "bookmark_line"
         const val COLUMN_BOOKMARK_POSITION = "bookmark_position"
+        const val COLUMN_AUDIO_PATH = "audio_path"
+
+        const val TABLE_AUDIO_LINES = "audio_lines"
+        const val COLUMN_LINE_INDEX = "line_index"
+        const val COLUMN_FILE_PATH = "file_path"
 
         const val TABLE_SETTINGS = "settings"
         const val COLUMN_KEY = "key"
@@ -33,8 +38,17 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME
                 "$COLUMN_MODE TEXT," +
                 "$COLUMN_SPEED REAL," +
                 "$COLUMN_BOOKMARK_LINE INTEGER," +
-                "$COLUMN_BOOKMARK_POSITION INTEGER)"
+                "$COLUMN_BOOKMARK_POSITION INTEGER," +
+                "$COLUMN_AUDIO_PATH TEXT)"
         db.execSQL(createProjectsTable)
+
+        val createAudioLinesTable = "CREATE TABLE $TABLE_AUDIO_LINES (" +
+                "$COLUMN_ID INTEGER PRIMARY KEY AUTOINCREMENT," +
+                "$COLUMN_URI TEXT," +
+                "$COLUMN_LINE_INDEX INTEGER," +
+                "$COLUMN_FILE_PATH TEXT," +
+                "UNIQUE($COLUMN_URI, $COLUMN_LINE_INDEX))"
+        db.execSQL(createAudioLinesTable)
 
         val createSettingsTable = "CREATE TABLE $TABLE_SETTINGS (" +
                 "$COLUMN_ID INTEGER PRIMARY KEY AUTOINCREMENT," +
@@ -46,6 +60,7 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
         db.execSQL("DROP TABLE IF EXISTS $TABLE_PROJECTS")
         db.execSQL("DROP TABLE IF EXISTS $TABLE_SETTINGS")
+        db.execSQL("DROP TABLE IF EXISTS $TABLE_AUDIO_LINES")
         onCreate(db)
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/utils/DatabaseManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/DatabaseManager.kt
@@ -19,6 +19,7 @@ object DatabaseManager {
             put(DatabaseHelper.COLUMN_WEIGHTS, weightsJson)
             put(DatabaseHelper.COLUMN_MODE, project.mode.name)
             put(DatabaseHelper.COLUMN_SPEED, project.speed)
+            project.audioPath?.let { put(DatabaseHelper.COLUMN_AUDIO_PATH, it) }
             project.bookmark?.let {
                 put(DatabaseHelper.COLUMN_BOOKMARK_LINE, it.line)
                 put(DatabaseHelper.COLUMN_BOOKMARK_POSITION, it.position)
@@ -56,8 +57,10 @@ object DatabaseManager {
             val bookmarkLine = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_BOOKMARK_LINE))
             val bookmarkPosition = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_BOOKMARK_POSITION))
             val bookmark = if (bookmarkLine != -1) Bookmark(bookmarkLine, bookmarkPosition) else null
+            val audioPathIndex = cursor.getColumnIndex(DatabaseHelper.COLUMN_AUDIO_PATH)
+            val audioPath = if (audioPathIndex != -1) cursor.getString(audioPathIndex) else null
 
-            project = Project(uri, styles, weights, mode, speed, bookmark)
+            project = Project(uri, styles, weights, mode, speed, bookmark, audioPath)
         }
 
         cursor.close()
@@ -111,6 +114,46 @@ object DatabaseManager {
             put(DatabaseHelper.COLUMN_BOOKMARK_POSITION, -1)
         }
         db.update(DatabaseHelper.TABLE_PROJECTS, values, "${DatabaseHelper.COLUMN_URI} = ?", arrayOf(uri))
+        db.close()
+    }
+
+    fun setAudioLine(context: Context, uri: String, index: Int, path: String) {
+        val dbHelper = DatabaseHelper(context)
+        val db = dbHelper.writableDatabase
+        val values = ContentValues().apply {
+            put(DatabaseHelper.COLUMN_URI, uri)
+            put(DatabaseHelper.COLUMN_LINE_INDEX, index)
+            put(DatabaseHelper.COLUMN_FILE_PATH, path)
+        }
+        db.replace(DatabaseHelper.TABLE_AUDIO_LINES, null, values)
+        db.close()
+    }
+
+    fun getAudioLine(context: Context, uri: String, index: Int): String? {
+        val dbHelper = DatabaseHelper(context)
+        val db = dbHelper.readableDatabase
+        val cursor = db.query(
+            DatabaseHelper.TABLE_AUDIO_LINES,
+            arrayOf(DatabaseHelper.COLUMN_FILE_PATH),
+            "${DatabaseHelper.COLUMN_URI} = ? AND ${DatabaseHelper.COLUMN_LINE_INDEX} = ?",
+            arrayOf(uri, index.toString()),
+            null,
+            null,
+            null
+        )
+        var path: String? = null
+        if (cursor.moveToFirst()) {
+            path = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_FILE_PATH))
+        }
+        cursor.close()
+        db.close()
+        return path
+    }
+
+    fun clearAudioLines(context: Context, uri: String) {
+        val dbHelper = DatabaseHelper(context)
+        val db = dbHelper.writableDatabase
+        db.delete(DatabaseHelper.TABLE_AUDIO_LINES, "${DatabaseHelper.COLUMN_URI} = ?", arrayOf(uri))
         db.close()
     }
 

--- a/app/src/main/java/com/example/kokoro82m/utils/WaveHelper.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/WaveHelper.kt
@@ -68,6 +68,24 @@ fun saveAudio(audioData: FloatArray, context: Context, name: String) {
     }
 }
 
+fun saveAudioInternal(audioData: FloatArray, file: java.io.File) {
+    val sampleRate = 22050
+    val header = createWavHeader(audioData.size, sampleRate)
+
+    val byteBuffer = ByteBuffer.allocate(audioData.size * 2)
+    byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
+    val shortBuffer = byteBuffer.asShortBuffer()
+    for (sample in audioData) {
+        val pcmValue = (sample * Short.MAX_VALUE).toInt().toShort()
+        shortBuffer.put(pcmValue)
+    }
+
+    file.outputStream().use { outputStream ->
+        outputStream.write(header)
+        outputStream.write(byteBuffer.array())
+    }
+}
+
 private fun createWavHeader(dataSize: Int, sampleRate: Int): ByteArray {
     val header = ByteArray(44)
     val totalDataSize = dataSize * 2 + 36


### PR DESCRIPTION
## Summary
- expand `DatabaseHelper` with tables for audio storage
- handle audio paths and line files in `DatabaseManager`
- add `saveAudioInternal` helper and new `preGenerateBook` util
- support pregeneration via button in `BookScreen`
- implement progress tracking reusable for downloads
- show progress for pregeneration and model downloads via `ProgressDialog`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889a8ea7ae88331beb92649ea5ff17c