### PR TITLE
Implement streaming TTS pipeline

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/utils/SentenceSplitter.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/SentenceSplitter.kt
@@ -1,0 +1,45 @@
+package com.example.kokoro82m.utils
+
+import java.util.regex.Pattern
+
+/**
+ * A utility class that buffers text and invokes a callback for each complete sentence.
+ */
+class SentenceSplitter(private val onSentenceReady: (String) -> Unit) {
+    private val buffer = StringBuilder()
+    // This regex looks for sentence-ending punctuation that is followed by a space or the end of the text.
+    private val sentenceEndPattern: Pattern = Pattern.compile("(?<=[.!?])(?=\\s|$)")
+
+    /**
+     * Processes an incoming chunk of text, identifies complete sentences, and invokes the callback.
+     * Any partial sentence at the end is kept in the buffer.
+     */
+    fun process(textChunk: String) {
+        buffer.append(textChunk)
+        val potentialSentences = sentenceEndPattern.split(buffer.toString())
+
+        if (potentialSentences.size > 1) {
+            // All parts except the last are considered complete sentences.
+            for (i in 0 until potentialSentences.size - 1) {
+                val sentence = potentialSentences[i].trim()
+                if (sentence.isNotEmpty()) {
+                    onSentenceReady(sentence)
+                }
+            }
+            // The last, incomplete part becomes the new buffer content.
+            buffer.clear().append(potentialSentences.last())
+        }
+    }
+
+    /**
+     * Call this when the stream is finished to process any remaining text in the buffer.
+     */
+    fun flush() {
+        val remaining = buffer.toString().trim()
+        if (remaining.isNotEmpty()) {
+            onSentenceReady(remaining)
+        }
+        buffer.clear()
+    }
+}
+

--- a/app/src/main/java/com/example/kokoro82m/utils/StreamingAudioPlayer.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/StreamingAudioPlayer.kt
@@ -1,0 +1,101 @@
+package com.example.kokoro82m.utils
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioTrack
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class StreamingAudioPlayer(
+    private val scope: CoroutineScope,
+    private val onStateChanged: (PlayerState) -> Unit
+) {
+    private var audioTrack: AudioTrack? = null
+    private var playbackJob: Job? = null
+    private val audioChannel = Channel<FloatArray>(Channel.UNLIMITED)
+
+    private val sampleRate = 22050
+
+    fun start() {
+        if (playbackJob?.isActive == true) return
+        playbackJob = scope.launch(Dispatchers.IO) {
+            initAudioTrack()
+            audioTrack?.play()
+            onStateChanged(PlayerState.PLAYING)
+
+            try {
+                // This loop consumes audio chunks from the channel and writes them to the AudioTrack.
+                for (audioChunk in audioChannel) {
+                    if (!isActive) break
+                    writeAudioData(audioChunk)
+                }
+            } finally {
+                stopAndRelease()
+            }
+        }
+    }
+
+    // Called by the TTS generator to add audio to the playback queue.
+    fun queueAudio(audioData: FloatArray) {
+        if (!audioChannel.isClosedForSend) {
+            scope.launch {
+                audioChannel.send(audioData)
+            }
+        }
+    }
+
+    // Call this when the LLM response is complete to signal the end of the audio stream.
+    fun stop() {
+        audioChannel.close() // Closing the channel gracefully terminates the consumer loop.
+    }
+
+    private fun initAudioTrack() {
+        if (audioTrack != null) return
+        val bufferSize = AudioTrack.getMinBufferSize(sampleRate, AudioFormat.CHANNEL_OUT_MONO, AudioFormat.ENCODING_PCM_16BIT)
+        audioTrack = AudioTrack(
+            AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC).build(),
+            AudioFormat.Builder()
+                .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                .setSampleRate(sampleRate)
+                .setChannelMask(AudioFormat.CHANNEL_OUT_MONO).build(),
+            bufferSize * 2, // Use a larger buffer for streaming to avoid underruns.
+            AudioTrack.MODE_STREAM,
+            AudioManager.AUDIO_SESSION_ID_GENERATE
+        )
+    }
+
+    private fun writeAudioData(audioData: FloatArray) {
+        val pcmData = convertFloatToPcm16(audioData)
+        audioTrack?.write(pcmData, 0, pcmData.size)
+    }
+
+    private fun convertFloatToPcm16(audioData: FloatArray): ByteArray {
+        val byteBuffer = ByteBuffer.allocate(audioData.size * 2).order(ByteOrder.LITTLE_ENDIAN)
+        val shortBuffer = byteBuffer.asShortBuffer()
+        for (sample in audioData) {
+            val pcmValue = (sample * Short.MAX_VALUE).coerceIn(Short.MIN_VALUE.toFloat(), Short.MAX_VALUE.toFloat()).toInt().toShort()
+            shortBuffer.put(pcmValue)
+        }
+        return byteBuffer.array()
+    }
+
+    private fun stopAndRelease() {
+        audioTrack?.let {
+            if (it.playState == AudioTrack.PLAYSTATE_PLAYING) it.stop()
+            it.flush()
+            it.release()
+        }
+        audioTrack = null
+        onStateChanged(PlayerState.IDLE)
+    }
+}
+

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
@@ -1,17 +1,18 @@
 package com.example.kokoro82m.viewmodel
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ai.onnxruntime.OrtSession
 import com.example.kokoro.chat.ChatMessage
 import com.example.kokoro.chat.LlmInference
-import com.example.kokoro82m.utils.AudioPlayer
 import com.example.kokoro82m.utils.InterpolationMode
 import com.example.kokoro82m.utils.PhonemeConverter
 import com.example.kokoro82m.utils.PlayerState
+import com.example.kokoro82m.utils.SentenceSplitter
 import com.example.kokoro82m.utils.StyleLoader
-import com.example.kokoro82m.utils.DebugLogger
+import com.example.kokoro82m.utils.StreamingAudioPlayer
 import com.example.kokoro82m.utils.createAudioFromStyleVector
 import com.example.kokoro82m.utils.mixStyles
 import kotlinx.coroutines.Dispatchers
@@ -30,9 +31,6 @@ class ChatTtsViewModel(
     // Dependencies
     private val phonemeConverter = PhonemeConverter(context)
     val styleLoader = StyleLoader(context)
-    private val audioPlayer = AudioPlayer(viewModelScope) { newState ->
-        _playerState.value = newState
-    }
 
     // Chat State
     private val _chatMessages = MutableStateFlow<List<ChatMessage>>(emptyList())
@@ -41,23 +39,21 @@ class ChatTtsViewModel(
     private val _isLoading = MutableStateFlow(false)
     val isLoading = _isLoading.asStateFlow()
 
-    // TTS State
-    private val _isSynthesizing = MutableStateFlow(false)
-    val isSynthesizing = _isSynthesizing.asStateFlow()
-
+    // TTS & Player State
     private val _playerState = MutableStateFlow(PlayerState.IDLE)
     val playerState = _playerState.asStateFlow()
+
+    private val streamingAudioPlayer = StreamingAudioPlayer(viewModelScope) { newState ->
+        _playerState.value = newState
+    }
 
     // Mixer State
     private val _selectedStyles = MutableStateFlow(listOf("af_sarah"))
     val selectedStyles = _selectedStyles.asStateFlow()
-
     private val _weights = MutableStateFlow(mapOf("af_sarah" to 1f))
     val weights = _weights.asStateFlow()
-
     private val _interpolationMode = MutableStateFlow(InterpolationMode.LINEAR)
     val interpolationMode = _interpolationMode.asStateFlow()
-
     private val _speed = MutableStateFlow(1.0f)
     val speed = _speed.asStateFlow()
 
@@ -66,66 +62,62 @@ class ChatTtsViewModel(
     }
 
     fun sendMessage(message: String) {
-        DebugLogger.log("ChatTtsViewModel sendMessage: $message")
+        // Prevent new messages while one is processing
+        if (_isLoading.value || _playerState.value == PlayerState.PLAYING) return
+        
         _chatMessages.value += ChatMessage(message, true)
         _isLoading.value = true
+        _chatMessages.value += ChatMessage("...", false) // UI placeholder
+
+        // --- Start of new streaming logic ---
+        streamingAudioPlayer.start() // Prepare the player to receive audio data.
 
         val responseBuilder = StringBuilder()
-        _chatMessages.value += ChatMessage("...", false)  // placeholder
+        
+        // This helper will feed us complete sentences.
+        val sentenceSplitter = SentenceSplitter { sentence ->
+            // Launch a new background job for each sentence to generate TTS concurrently.
+            viewModelScope.launch {
+                synthesizeAndQueue(sentence)
+            }
+        }
 
-        viewModelScope.launch(Dispatchers.IO) { // 1. Outer scope for IO work
-            llmInference.sendMessage(message) { partial, done -> // 2. This is a REGULAR callback
+        llmInference.sendMessage(message) { partialResult, done ->
+            viewModelScope.launch(Dispatchers.Main) { // UI updates must happen on the Main thread.
+                responseBuilder.append(partialResult)
+                
+                // Update the UI with the latest streaming text from the LLM.
+                val last = _chatMessages.value.last()
+                _chatMessages.value = _chatMessages.value.dropLast(1) + last.copy(message = responseBuilder.toString())
+
                 if (!done) {
-                    responseBuilder.append(partial)
-                    val last = _chatMessages.value.last()
-                    _chatMessages.value =
-                        _chatMessages.value.dropLast(1) + last.copy(message = responseBuilder.toString())
+                    sentenceSplitter.process(partialResult)
                 } else {
-                    // 3. Hop back to the main thread safely for UI updates & suspend function calls
-                    viewModelScope.launch { // Defaults to Main dispatcher for viewModelScope
-                        _isLoading.value = false
-                        DebugLogger.log("ChatTtsViewModel response complete")
-                        synthesizeAndPlay(responseBuilder.toString()) // synthesizeAndPlay can now be called
-                    }
+                    _isLoading.value = false
+                    sentenceSplitter.flush() // Process any remaining text in the buffer.
+                    
+                    // Signal the player that no more audio is coming. It will finish playing its queue and then stop.
+                    streamingAudioPlayer.stop()
                 }
             }
         }
     }
 
-
-    private fun synthesizeAndPlay(text: String) {
-        viewModelScope.launch {
-            _isSynthesizing.value = true
-            try {
-                // Perform all heavy computations on a background thread
-                val audioData = withContext(Dispatchers.IO) {
-                    val mixedVector = mixStyles(
-                        styleLoader,
-                        _selectedStyles.value,
-                        _weights.value,
-                        _interpolationMode.value
-                    )
-                    val phonemes = phonemeConverter.phonemize(text)
-
-                    val (data, _) = createAudioFromStyleVector(
-                        phonemes = phonemes,
-                        voice = mixedVector,
-                        speed = _speed.value,
-                        session = ortSession
-                    )
-                    data // Return the resulting audio data
-                }
-
-                // Switch back to the main thread to update UI and play audio
-                _isSynthesizing.value = false
-                audioPlayer.prepare(audioData)
-                audioPlayer.play()
-
-            } catch (e: Exception) {
-                _isSynthesizing.value = false
-                // Handle error, e.g., show a toast
-                android.util.Log.e("ChatTtsViewModel", "Error synthesizing audio", e)
+    private suspend fun synthesizeAndQueue(text: String) {
+        if (text.isBlank()) return
+        
+        try {
+            // Perform all heavy computation on a background thread.
+            val (audioData, _) = withContext(Dispatchers.IO) {
+                val mixedVector = mixStyles(styleLoader, _selectedStyles.value, _weights.value, _interpolationMode.value)
+                val phonemes = phonemeConverter.phonemize(text)
+                createAudioFromStyleVector(phonemes, mixedVector, _speed.value, ortSession)
             }
+            // Queue the generated audio for playback.
+            streamingAudioPlayer.queueAudio(audioData)
+
+        } catch (e: Exception) {
+            Log.e("ChatTtsViewModel", "Error synthesizing audio for text: '$text'", e)
         }
     }
 
@@ -141,7 +133,7 @@ class ChatTtsViewModel(
         _selectedStyles.value -= style
         _weights.value -= style
         if (_selectedStyles.value.isEmpty()) {
-            addStyle("af_sarah") // Ensure at least one style is always selected
+            addStyle("af_sarah") // Ensure at least one style is always selected.
         }
     }
 
@@ -160,6 +152,7 @@ class ChatTtsViewModel(
     override fun onCleared() {
         super.onCleared()
         llmInference.close()
-        audioPlayer.stop()
+        streamingAudioPlayer.stop() // Ensure all resources are released.
     }
 }
+


### PR DESCRIPTION
## Summary
- Add `SentenceSplitter` utility to emit sentences from streaming text chunks
- Introduce `StreamingAudioPlayer` for queued audio playback
- Refactor `ChatTtsViewModel` to synthesize and queue sentence audio as LLM text streams

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d904791008331a7b3bd4245c38d6e