### PR TITLE
Enable background model downloads with notifications

### DIFF
--- a/app/src/main/java/com/example/kokoro/galleryport/LlmController.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/LlmController.kt
@@ -19,9 +19,8 @@ class LlmController private constructor(val llm: LlmInference) {
                 return null
             }
 
-            val modelFile = File(ctx.filesDir, "models/${model.id}.task")
+            val modelFile = model.localPath?.let { File(it) } ?: File(ctx.filesDir, "models/${model.id}.task")
             if (!modelFile.exists()) return null
-
 
             val opts = LlmInference.LlmInferenceOptions.builder()
                 .setModelPath(modelFile.absolutePath)

--- a/app/src/main/java/com/example/kokoro/galleryport/ModelHub.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/ModelHub.kt
@@ -9,7 +9,7 @@ object ModelHub {
         val modelManager = ModelManager(ctx)
         val model = modelManager.getModel(modelId) ?: return null
         if (!model.isDownloaded) return null
-        val modelFile = File(ctx.filesDir, "models/${model.id}.task")
+        val modelFile = model.localPath?.let { File(it) } ?: File(ctx.filesDir, "models/${model.id}.task")
         return if (modelFile.exists()) modelFile else null
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/ChatActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/ChatActivity.kt
@@ -58,7 +58,7 @@ class ChatActivity : ComponentActivity() {
     }
 
     private fun startChat(model: Model) {
-        val modelFile = File(filesDir, "models/${model.id}.task")
+        val modelFile = model.localPath?.let { File(it) } ?: File(filesDir, "models/${model.id}.task")
 
         val llmInference = LlmInference(
             context = applicationContext,

--- a/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
@@ -63,7 +63,7 @@ class ChatTtsActivity : ComponentActivity() {
     }
 
     private fun startChat(model: Model, session: ai.onnxruntime.OrtSession) {
-        val modelFile = File(filesDir, "models/${model.id}.task")
+        val modelFile = model.localPath?.let { File(it) } ?: File(filesDir, "models/${model.id}.task")
         val llmInference = LlmInference(applicationContext, modelFile.absolutePath)
 
         val viewModel: ChatTtsViewModel by viewModels {

--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -354,7 +354,8 @@ fun BasicScreen(
 
     LaunchedEffect(selectedModel) {
         selectedModel?.let {
-            val modelFile = java.io.File(context.filesDir, "models/${it.id}.task")
+            val modelFile = it.localPath?.let { path -> java.io.File(path) }
+                ?: java.io.File(context.filesDir, "models/${it.id}.task")
             viewModel.reinitializeSession(modelFile.absolutePath)
         }
     }

--- a/app/src/main/java/com/example/kokoro82m/data/DownloadWorker.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/DownloadWorker.kt
@@ -1,8 +1,15 @@
 package com.example.kokoro82m.data
 
 import android.content.Context
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
+import androidx.work.workDataOf
 import com.example.kokoro82m.utils.DebugLogger
 import java.io.File
 import java.io.FileOutputStream
@@ -12,22 +19,32 @@ import javax.net.ssl.HttpsURLConnection
 class DownloadWorker(appContext: Context, workerParams: WorkerParameters) :
     CoroutineWorker(appContext, workerParams) {
 
+    companion object {
+        private const val CHANNEL_ID = "model_download"
+        private const val NOTIFICATION_ID = 1
+    }
+
     override suspend fun doWork(): Result {
         DebugLogger.initialize(applicationContext)
         val modelId = inputData.getString("model_id")
         val downloadUrl = inputData.getString("download_url")
         val hfToken = inputData.getString("hf_token")
+        val modelName = inputData.getString("model_name") ?: modelId
 
         if (modelId.isNullOrEmpty() || downloadUrl.isNullOrEmpty()) {
             return Result.failure()
         }
+
+        createChannel()
+        setForeground(createForegroundInfo(0, modelName!!))
 
         return try {
             val modelDir = File(applicationContext.filesDir, "models")
             if (!modelDir.exists()) {
                 modelDir.mkdirs()
             }
-            val destinationFile = File(modelDir, "$modelId.task")
+            val finalFile = File(modelDir, "$modelId.task")
+            val tempFile = File(modelDir, "$modelId.task.part")
 
             DebugLogger.log("DownloadWorker: Starting download for model '$modelId' from: $downloadUrl")
 
@@ -37,33 +54,68 @@ class DownloadWorker(appContext: Context, workerParams: WorkerParameters) :
                 connection.setRequestProperty("Authorization", "Bearer $it")
                 DebugLogger.log("DownloadWorker: Authorization header set for Hugging Face.")
             }
+            val existing = if (tempFile.exists()) tempFile.length() else 0L
+            if (existing > 0) {
+                connection.setRequestProperty("Range", "bytes=$existing-")
+            }
             connection.connect()
 
-            val responseCode = connection.responseCode
-            DebugLogger.log("DownloadWorker: HTTP Response Code: $responseCode")
-
-            if (responseCode != HttpsURLConnection.HTTP_OK) {
-                DebugLogger.log("DownloadWorker: HTTP error $responseCode for URL: $downloadUrl")
-                return Result.failure()
-            }
-
-            val inputStream = connection.getInputStream()
-            val outputStream = FileOutputStream(destinationFile)
+            val totalLen = connection.getHeaderFieldInt("Content-Length", -1)
+            val total = if (totalLen > 0) totalLen + existing else -1
+            val inputStream = connection.inputStream
+            val outputStream = FileOutputStream(tempFile, existing > 0)
 
             val buffer = ByteArray(1024)
             var len: Int
+            var downloaded = existing
             while (inputStream.read(buffer).also { len = it } != -1) {
                 outputStream.write(buffer, 0, len)
+                downloaded += len
+                if (total > 0) {
+                    val progress = downloaded.toFloat() / total
+                    setProgress(workDataOf("progress" to progress))
+                    setForeground(createForegroundInfo((progress * 100).toInt(), modelName))
+                }
             }
 
             outputStream.close()
             inputStream.close()
 
-            DebugLogger.log("DownloadWorker: Model '$modelId' downloaded successfully to ${destinationFile.absolutePath}")
+            tempFile.renameTo(finalFile)
+
+            val finished = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+                .setContentTitle("$modelName downloaded")
+                .setSmallIcon(android.R.drawable.stat_sys_download_done)
+                .build()
+            NotificationManagerCompat.from(applicationContext).notify(NOTIFICATION_ID, finished)
+
+            DebugLogger.log("DownloadWorker: Model '$modelId' downloaded successfully to ${finalFile.absolutePath}")
             Result.success()
         } catch (e: Exception) {
             DebugLogger.log("DownloadWorker: Error downloading model '$modelId' from $downloadUrl - ${e.message}")
             Result.failure()
+        }
+    }
+
+    private fun createForegroundInfo(progress: Int, modelName: String): ForegroundInfo {
+        val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+            .setContentTitle("Downloading $modelName")
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setOngoing(true)
+            .setProgress(100, progress, progress == 0)
+            .build()
+        return ForegroundInfo(NOTIFICATION_ID, notification)
+    }
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Model Downloads",
+                NotificationManager.IMPORTANCE_LOW
+            )
+            val manager = applicationContext.getSystemService(NotificationManager::class.java)
+            manager.createNotificationChannel(channel)
         }
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/data/Model.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/Model.kt
@@ -9,4 +9,5 @@ data class Model(
     val gated: Boolean,
     var isDownloaded: Boolean = false,
     var hasPartial: Boolean = false,
+    var localPath: String? = null,
 )

--- a/app/src/main/java/com/example/kokoro82m/data/ModelDownloader.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/ModelDownloader.kt
@@ -1,16 +1,18 @@
 package com.example.kokoro82m.data
 
 import android.content.Context
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.getWorkInfoByIdFlow
+import androidx.work.workDataOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.io.File
-import java.io.FileOutputStream
-import java.net.URL
-import javax.net.ssl.HttpsURLConnection
 import com.example.kokoro82m.utils.DebugLogger
 
 class ModelDownloader(
@@ -20,6 +22,8 @@ class ModelDownloader(
     private val scope = CoroutineScope(Dispatchers.IO)
     private val _progress = MutableStateFlow<Map<String, Float>>(emptyMap())
     val progress: StateFlow<Map<String, Float>> = _progress
+
+    private val workManager = WorkManager.getInstance(context)
 
     fun downloadModel(model: Model) {
         scope.launch {
@@ -32,53 +36,36 @@ class ModelDownloader(
             if (finalFile.exists()) {
                 model.isDownloaded = true
                 model.hasPartial = false
+                model.localPath = finalFile.absolutePath
                 DebugLogger.log("ModelDownloader: ${model.name} already downloaded")
                 return@launch
             }
 
-            val existingSize = if (tempFile.exists()) tempFile.length() else 0L
-            model.hasPartial = existingSize > 0
+            model.hasPartial = tempFile.exists()
 
-            try {
-                DebugLogger.log("ModelDownloader: Starting download of ${model.name}")
-                val url = URL(model.downloadUrl)
-                val connection = url.openConnection() as HttpsURLConnection
-                token?.let { connection.setRequestProperty("Authorization", "Bearer $it") }
-                if (existingSize > 0) {
-                    connection.setRequestProperty("Range", "bytes=$existingSize-")
+            val request = OneTimeWorkRequestBuilder<DownloadWorker>()
+                .setInputData(
+                    workDataOf(
+                        "model_id" to model.id,
+                        "download_url" to model.downloadUrl,
+                        "hf_token" to token,
+                        "model_name" to model.name
+                    )
+                )
+                .build()
+            workManager.enqueue(request)
+
+            workManager.getWorkInfoByIdFlow(request.id).collect { info ->
+                val p = info.progress.getFloat("progress", -1f)
+                if (p >= 0f) {
+                    _progress.value = _progress.value.toMutableMap().apply { put(model.id, p) }
                 }
-                connection.connect()
-
-                val contentLength = connection.getHeaderFieldInt("Content-Length", -1)
-                val total = if (contentLength > 0) contentLength + existingSize else -1
-                val input = connection.inputStream
-
-                val output = FileOutputStream(tempFile, existingSize > 0)
-
-                val buffer = ByteArray(1024)
-                var bytesRead: Int
-                var downloaded = existingSize
-                while (input.read(buffer).also { bytesRead = it } != -1) {
-                    output.write(buffer, 0, bytesRead)
-                    downloaded += bytesRead
-                    if (total > 0) {
-                        val p = downloaded.toFloat() / total
-                        _progress.value = _progress.value.toMutableMap().apply { put(model.id, p) }
-                    }
+                if (info.state.isFinished) {
+                    _progress.value = _progress.value.toMutableMap().apply { remove(model.id) }
+                    model.isDownloaded = finalFile.exists()
+                    model.hasPartial = !model.isDownloaded && tempFile.exists()
+                    model.localPath = if (model.isDownloaded) finalFile.absolutePath else null
                 }
-
-                output.close()
-                input.close()
-
-                tempFile.renameTo(finalFile)
-                model.isDownloaded = true
-                model.hasPartial = false
-                DebugLogger.log("ModelDownloader: Download of ${model.name} completed")
-            } catch (e: Exception) {
-                model.hasPartial = tempFile.exists()
-                DebugLogger.log("ModelDownloader: Error downloading ${model.name}: ${e.message}")
-            } finally {
-                _progress.value = _progress.value.toMutableMap().apply { remove(model.id) }
             }
         }
     }

--- a/app/src/main/java/com/example/kokoro82m/data/ModelManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/ModelManager.kt
@@ -2,6 +2,7 @@ package com.example.kokoro82m.data
 
 import android.content.Context
 import com.example.kokoro82m.R
+import com.example.kokoro82m.utils.SettingsManager
 import org.json.JSONObject
 
 class ModelManager(private val context: Context) {
@@ -31,7 +32,29 @@ class ModelManager(private val context: Context) {
             val partialFile = java.io.File(modelDir, "${model.id}.task.part")
             model.isDownloaded = modelFile.exists()
             model.hasPartial = !model.isDownloaded && partialFile.exists()
+            model.localPath = if (model.isDownloaded) modelFile.absolutePath else null
             modelList.add(model)
+        }
+
+        SettingsManager.getModelDir(context)?.let { path ->
+            val dir = java.io.File(path)
+            if (dir.exists()) {
+                dir.listFiles { file -> file.extension == "task" || file.extension == "onnx" }?.forEach { file ->
+                    modelList.add(
+                        Model(
+                            id = file.nameWithoutExtension,
+                            name = file.nameWithoutExtension,
+                            description = "External model",
+                            repo = "",
+                            downloadUrl = "",
+                            gated = false,
+                            isDownloaded = true,
+                            hasPartial = false,
+                            localPath = file.absolutePath
+                        )
+                    )
+                }
+            }
         }
         return modelList
     }
@@ -41,10 +64,14 @@ class ModelManager(private val context: Context) {
     }
 
     fun deleteModel(model: Model) {
-        val modelDir = java.io.File(context.filesDir, "models")
-        java.io.File(modelDir, "${model.id}.task").delete()
-        java.io.File(modelDir, "${model.id}.task.part").delete()
+        val internalDir = java.io.File(context.filesDir, "models")
+        if (model.localPath != null && !model.localPath!!.startsWith(internalDir.absolutePath)) {
+            return
+        }
+        java.io.File(internalDir, "${model.id}.task").delete()
+        java.io.File(internalDir, "${model.id}.task.part").delete()
         model.isDownloaded = false
         model.hasPartial = false
+        model.localPath = null
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
@@ -118,10 +118,12 @@ fun ModelsScreen(userPreferencesRepository: UserPreferencesRepository) {
                         if (model.isDownloaded) {
                             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                                 Text("Downloaded")
-                                Button(onClick = {
-                                    DebugLogger.log("ModelsScreen: Deleting ${model.name}")
-                                    modelManager.deleteModel(model)
-                                }) { Text("Delete") }
+                                if (model.localPath?.startsWith(context.filesDir.path) != false) {
+                                    Button(onClick = {
+                                        DebugLogger.log("ModelsScreen: Deleting ${model.name}")
+                                        modelManager.deleteModel(model)
+                                    }) { Text("Delete") }
+                                }
                             }
                         } else if (progress != null) {
                             LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())

--- a/app/src/main/java/com/example/kokoro82m/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/SettingsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -20,6 +21,7 @@ import com.example.kokoro82m.utils.SettingsManager
 fun SettingsScreen() {
     val context = LocalContext.current
     var debug by remember { mutableStateOf(SettingsManager.isDebug(context)) }
+    var modelDir by remember { mutableStateOf(SettingsManager.getModelDir(context) ?: "") }
 
     Column(modifier = Modifier.padding(16.dp)) {
         androidx.compose.foundation.layout.Row(verticalAlignment = Alignment.CenterVertically) {
@@ -32,5 +34,17 @@ fun SettingsScreen() {
             )
             Text(text = "Debug Mode", modifier = Modifier.padding(start = 8.dp))
         }
+
+        TextField(
+            value = modelDir,
+            onValueChange = {
+                modelDir = it
+                SettingsManager.setModelDir(context, it)
+            },
+            label = { Text("Model directory") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp)
+        )
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/utils/SettingsManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/SettingsManager.kt
@@ -23,4 +23,11 @@ object SettingsManager {
 
     fun getSpeed(context: Context, default: Float = 1.0f): Float =
         DatabaseManager.getSetting(context, "speed")?.toFloat() ?: default
+
+    fun setModelDir(context: Context, path: String) {
+        DatabaseManager.setSetting(context, "model_dir", path)
+    }
+
+    fun getModelDir(context: Context): String? =
+        DatabaseManager.getSetting(context, "model_dir")
 }


### PR DESCRIPTION
## Summary
- move model downloads to a foreground `WorkManager` worker that posts notifications and updates progress
- add setting for a custom model directory and load external models from that path
- update model selection logic to use files from the custom directory

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dc9404ff48331ace919478a31ddbe