### PR TITLE
Persist book URI permissions and handle load failures

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -1,6 +1,7 @@
 package com.example.kokoro82m.screens
 
 import ai.onnxruntime.OrtSession
+import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -68,6 +69,11 @@ fun BookScreen(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri: Uri? ->
         uri?.let {
+            // Persist read permission so the URI can be reopened later from saved projects
+            context.contentResolver.takePersistableUriPermission(
+                it,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
+            )
             bookViewModel.loadBook(context, it)
         }
     }

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
@@ -42,7 +42,11 @@ class BookViewModel : ViewModel() {
     fun loadBook(context: Context, uri: Uri) {
         _bookUri.value = uri
         viewModelScope.launch(Dispatchers.IO) {
-            val text = context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() } ?: ""
+            val text = try {
+                context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
+            } catch (e: Exception) {
+                null
+            } ?: ""
             withContext(Dispatchers.Main) {
                 _lines.value = text.lines()
             }


### PR DESCRIPTION
## Summary
- persist read permission for selected books so saved projects can reopen without crashing
- guard against exceptions when loading book text

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e923c8efc8331ae1202161b950f50