### PR TITLE
Add performance HUD and runtime benchmarking

### DIFF
--- a/app-chat/src/main/java/com/example/kokoro/chat/LlmInference.kt
+++ b/app-chat/src/main/java/com/example/kokoro/chat/LlmInference.kt
@@ -5,6 +5,7 @@ import com.google.mediapipe.tasks.genai.llminference.LlmInference
 import com.google.mediapipe.tasks.genai.llminference.LlmInference.LlmInferenceOptions
 import java.io.File
 import com.example.kokoro82m.utils.DebugLogger
+import com.example.kokoro.galleryport.PerfHud
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -35,7 +36,14 @@ class LlmInference(
         }
 
         DebugLogger.log("LlmInference sendMessage: $prompt")
-        llmInference?.generateResponseAsync(prompt, resultListener)
+        val start = System.nanoTime()
+        llmInference?.generateResponseAsync(prompt) { partial, done ->
+            if (done) {
+                val ms = (System.nanoTime() - start) / 1e6f
+                PerfHud.recordValue("LLM", ms)
+            }
+            resultListener(partial, done)
+        }
     }
 
     fun close() {

--- a/app-chat/src/main/java/com/example/kokoro/chat/LlmInference.kt
+++ b/app-chat/src/main/java/com/example/kokoro/chat/LlmInference.kt
@@ -5,7 +5,6 @@ import com.google.mediapipe.tasks.genai.llminference.LlmInference
 import com.google.mediapipe.tasks.genai.llminference.LlmInference.LlmInferenceOptions
 import java.io.File
 import com.example.kokoro82m.utils.DebugLogger
-import com.example.kokoro.galleryport.PerfHud
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/app-chat/src/main/java/com/example/kokoro/chat/PerfHud.kt
+++ b/app-chat/src/main/java/com/example/kokoro/chat/PerfHud.kt
@@ -1,4 +1,4 @@
-package com.example.kokoro.galleryport
+package com.example.kokoro.chat
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -11,9 +11,15 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlin.system.measureNanoTime
 
+/**
+ * Simple performance HUD for tracking synchronous and asynchronous metrics.
+ * The stats map can be updated manually via [recordValue] or by wrapping a block
+ * with [record] to measure its execution time.
+ */
 object PerfHud {
     private val stats = mutableStateMapOf<String, Float>()
 
+    /** Measure the execution time of [block] and store the result under [label]. */
     fun <T> record(label: String, block: () -> T): T {
         var result: T? = null
         val ms = measureNanoTime { result = block() } / 1e6f
@@ -21,10 +27,12 @@ object PerfHud {
         return result!!
     }
 
+    /** Manually update the metric associated with [label]. */
     fun recordValue(label: String, ms: Float) {
         stats[label] = ms
     }
 
+    /** Overlay composable displaying the latest metrics. */
     @Composable
     fun Overlay() {
         Column(Modifier.padding(6.dp)) {
@@ -34,3 +42,4 @@ object PerfHud {
         }
     }
 }
+

--- a/app/src/main/java/com/example/kokoro/galleryport/PerfHud.kt
+++ b/app/src/main/java/com/example/kokoro/galleryport/PerfHud.kt
@@ -21,6 +21,10 @@ object PerfHud {
         return result!!
     }
 
+    fun recordValue(label: String, ms: Float) {
+        stats[label] = ms
+    }
+
     @Composable
     fun Overlay() {
         Column(Modifier.padding(6.dp)) {

--- a/app/src/main/java/com/example/kokoro82m/ChatActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/ChatActivity.kt
@@ -15,7 +15,7 @@ import com.example.kokoro82m.data.ModelManager
 import com.example.kokoro82m.data.Model
 import com.example.kokoro82m.utils.DebugLogger
 import androidx.compose.foundation.layout.Box
-import com.example.kokoro.galleryport.PerfHud
+import com.example.kokoro.chat.PerfHud
 import java.io.File
 
 class ChatActivity : ComponentActivity() {

--- a/app/src/main/java/com/example/kokoro82m/ChatActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/ChatActivity.kt
@@ -14,6 +14,8 @@ import com.example.kokoro.chat.LlmInference
 import com.example.kokoro82m.data.ModelManager
 import com.example.kokoro82m.data.Model
 import com.example.kokoro82m.utils.DebugLogger
+import androidx.compose.foundation.layout.Box
+import com.example.kokoro.galleryport.PerfHud
 import java.io.File
 
 class ChatActivity : ComponentActivity() {
@@ -75,11 +77,14 @@ class ChatActivity : ComponentActivity() {
         }
 
         setContent {
-            ChatScreen(
-                viewModel = viewModel,
-                modelName = model.name,
-                onBackPressed = { finish() }
-            )
+            Box {
+                ChatScreen(
+                    viewModel = viewModel,
+                    modelName = model.name,
+                    onBackPressed = { finish() }
+                )
+                PerfHud.Overlay()
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
@@ -16,6 +16,8 @@ import com.example.kokoro82m.screens.ChatTtsScreen
 import com.example.kokoro82m.utils.OnnxRuntimeManager
 import com.example.kokoro82m.utils.DebugLogger
 import com.example.kokoro82m.viewmodel.ChatTtsViewModel
+import androidx.compose.foundation.layout.Box
+import com.example.kokoro.galleryport.PerfHud
 import java.io.File
 
 class ChatTtsActivity : ComponentActivity() {
@@ -80,7 +82,10 @@ class ChatTtsActivity : ComponentActivity() {
 
         setContent {
             KokoroTheme {
-                ChatTtsScreen(viewModel = viewModel, modelName = model.name, onBackPressed = { finish() })
+                Box {
+                    ChatTtsScreen(viewModel = viewModel, modelName = model.name, onBackPressed = { finish() })
+                    PerfHud.Overlay()
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
@@ -17,7 +17,7 @@ import com.example.kokoro82m.utils.OnnxRuntimeManager
 import com.example.kokoro82m.utils.DebugLogger
 import com.example.kokoro82m.viewmodel.ChatTtsViewModel
 import androidx.compose.foundation.layout.Box
-import com.example.kokoro.galleryport.PerfHud
+import com.example.kokoro.chat.PerfHud
 import java.io.File
 
 class ChatTtsActivity : ComponentActivity() {

--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -7,7 +7,7 @@ import com.example.kokoro82m.screens.SettingsScreen
 import com.example.kokoro82m.screens.MixerScreen
 import com.example.kokoro82m.screens.MoreScreen
 import com.example.kokoro82m.screens.ModelsScreen
-import com.example.kokoro.galleryport.PerfHud
+import com.example.kokoro.chat.PerfHud
 import ai.onnxruntime.OrtSession
 import android.app.Application
 import android.content.Context

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
@@ -14,7 +14,7 @@ import com.example.kokoro82m.utils.StyleLoader
 import com.example.kokoro82m.utils.DebugLogger
 import com.example.kokoro82m.utils.createAudioFromStyleVector
 import com.example.kokoro82m.utils.mixStyles
-import com.example.kokoro.galleryport.PerfHud
+import com.example.kokoro.chat.PerfHud
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
@@ -14,6 +14,7 @@ import com.example.kokoro82m.utils.StyleLoader
 import com.example.kokoro82m.utils.DebugLogger
 import com.example.kokoro82m.utils.createAudioFromStyleVector
 import com.example.kokoro82m.utils.mixStyles
+import com.example.kokoro.galleryport.PerfHud
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -99,21 +100,23 @@ class ChatTtsViewModel(
             try {
                 // Perform all heavy computations on a background thread
                 val audioData = withContext(Dispatchers.IO) {
-                    val mixedVector = mixStyles(
-                        styleLoader,
-                        _selectedStyles.value,
-                        _weights.value,
-                        _interpolationMode.value
-                    )
-                    val phonemes = phonemeConverter.phonemize(text)
+                    PerfHud.record("TTS") {
+                        val mixedVector = mixStyles(
+                            styleLoader,
+                            _selectedStyles.value,
+                            _weights.value,
+                            _interpolationMode.value
+                        )
+                        val phonemes = phonemeConverter.phonemize(text)
 
-                    val (data, _) = createAudioFromStyleVector(
-                        phonemes = phonemes,
-                        voice = mixedVector,
-                        speed = _speed.value,
-                        session = ortSession
-                    )
-                    data // Return the resulting audio data
+                        val (data, _) = createAudioFromStyleVector(
+                            phonemes = phonemes,
+                            voice = mixedVector,
+                            speed = _speed.value,
+                            session = ortSession
+                        )
+                        data // Return the resulting audio data
+                    }
                 }
 
                 // Switch back to the main thread to update UI and play audio


### PR DESCRIPTION
## Summary
- overlay PerfHud on Chat and ChatTTS activities
- measure LLM response time through LlmInference
- track TTS synthesis duration in ChatTtsViewModel

## Testing
- `./gradlew :app:assembleDebug :app-chat:assembleDebug` *(failed: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `apt-get install -y gradle` *(failed: ca-certificates-java post-installation script error)*

------
https://chatgpt.com/codex/tasks/task_e_688f862504608331a1adafe982875c5f