### PR TITLE
Handle apostrophes in phonemizer and improve chat sentence parsing

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/utils/PhonemeConverter.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/PhonemeConverter.kt
@@ -67,8 +67,9 @@ class PhonemeConverter(context: Context) {
         println("normalText: $normalizedText")
 
 
-        val wordsAndPunctuation =
-            normalizedText.split(Regex("(?<=\\W)|(?=\\W)")).filter { it.isNotBlank() }
+        val wordsAndPunctuation = normalizedText
+            .split(Regex("(?<=[^\\p{L}\\p{N}'])|(?=[^\\p{L}\\p{N}'])"))
+            .filter { it.isNotBlank() }
 
 
         val phonemes = StringBuilder()

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
@@ -110,7 +110,8 @@ class ChatTtsViewModel(
 
     private fun processSentences(builder: StringBuilder, done: Boolean) {
         var text = builder.toString()
-        val regex = Regex("[.!?]")
+        // Treat consecutive punctuation as a single delimiter and also split on newlines
+        val regex = Regex("[.!?]+|\n")
         var match = regex.find(text)
         while (match != null) {
             val end = match.range.last + 1


### PR DESCRIPTION
## Summary
- Preserve apostrophes in word tokenization so words like "let's" are phonemized correctly.
- Make chat TTS sentence processing treat newline and grouped punctuation as single delimiters.

## Testing
- `gradle test` *(fails: 12 tests completed, 4 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688fc11ee8d0833199f97cdc2a35c189