### PR TITLE
Support additional book file types and streamline ingest

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -271,7 +271,7 @@ fun BookScreen(
                 horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.padding_small)),
                 maxItemsInEachRow = 3
             ) {
-                Button(onClick = { launcher.launch(arrayOf("text/plain")) }) {
+                Button(onClick = { launcher.launch(arrayOf("text/*", "application/epub+zip")) }) {
                     Text("Open")
                 }
                 Button(

--- a/app/src/main/java/com/example/kokoro82m/utils/TextFileReader.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/TextFileReader.kt
@@ -1,0 +1,45 @@
+package com.example.kokoro82m.utils
+
+import android.content.Context
+import android.net.Uri
+import java.io.InputStream
+import java.util.zip.ZipInputStream
+
+object TextFileReader {
+    fun read(context: Context, uri: Uri): String {
+        val mime = context.contentResolver.getType(uri) ?: ""
+        val stream = context.contentResolver.openInputStream(uri)
+        return stream?.use { read(it, mime) } ?: ""
+    }
+
+    fun read(stream: InputStream, mime: String): String {
+        return when {
+            mime == "application/epub+zip" -> readEpub(stream)
+            mime == "text/html" || mime == "application/xhtml+xml" -> {
+                val html = stream.bufferedReader().use { it.readText() }
+                stripHtml(html)
+            }
+            else -> stream.bufferedReader().use { it.readText() }
+        }
+    }
+
+    private fun readEpub(stream: InputStream): String {
+        val sb = StringBuilder()
+        ZipInputStream(stream).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                if (!entry.isDirectory && (entry.name.endsWith(".xhtml") || entry.name.endsWith(".html"))) {
+                    val html = zis.bufferedReader().use { it.readText() }
+                    sb.append(stripHtml(html)).append('\n')
+                }
+                entry = zis.nextEntry
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun stripHtml(html: String): String {
+        return html.replace(Regex("<[^>]*>"), "")
+    }
+}
+

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
@@ -11,6 +11,7 @@ import com.example.kokoro82m.utils.InterpolationMode
 import com.example.kokoro82m.utils.PhonemeConverter
 import com.example.kokoro82m.utils.PlayerState
 import com.example.kokoro82m.utils.StyleLoader
+import com.example.kokoro82m.utils.TextFileReader
 import com.example.kokoro82m.utils.playBook
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -43,12 +44,12 @@ class BookViewModel : ViewModel() {
         _bookUri.value = uri
         viewModelScope.launch(Dispatchers.IO) {
             val text = try {
-                context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
+                TextFileReader.read(context, uri)
             } catch (e: Exception) {
                 null
             } ?: ""
             withContext(Dispatchers.Main) {
-                _lines.value = text.lines()
+                _lines.value = text.lineSequence().toList()
             }
         }
     }

--- a/app/src/test/java/com/example/kokoro82m/utils/TextFileReaderTest.kt
+++ b/app/src/test/java/com/example/kokoro82m/utils/TextFileReaderTest.kt
@@ -1,0 +1,31 @@
+package com.example.kokoro82m.utils
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TextFileReaderTest {
+    @Test
+    fun readPlainText() {
+        val data = "Hello\nWorld"
+        val text = TextFileReader.read(ByteArrayInputStream(data.toByteArray()), "text/plain")
+        assertEquals(data, text)
+    }
+
+    @Test
+    fun readEpubHtml() {
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zos ->
+            zos.putNextEntry(ZipEntry("content.html"))
+            zos.write("<p>Hello</p>World".toByteArray())
+            zos.closeEntry()
+        }
+        val epubBytes = baos.toByteArray()
+        val text = TextFileReader.read(ByteArrayInputStream(epubBytes), "application/epub+zip")
+        assertEquals("HelloWorld\n", text)
+    }
+}
+


### PR DESCRIPTION
## Summary
- expand file picker to allow any text type and EPUB books
- add TextFileReader utility to normalize plain text, HTML, and EPUB content
- load books via TextFileReader and exercise new reader with unit tests

## Testing
- `./gradlew test` *(fails: 14 tests completed, 5 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688fcd765d448331bb092b84be7b2bc6