### PR TITLE
Handle line-based bookmarks and clipping tap behavior

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -7,7 +7,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -282,9 +281,8 @@ fun BookScreen(
                         if (playerState == PlayerState.PLAYING) {
                             bookViewModel.audioPlayer.pause()
                             bookUri?.let {
-                                val position = bookViewModel.audioPlayer.getPosition()
-                                DebugLogger.log("Saving bookmark at line $currentLine, position $position")
-                                BookmarkManager.save(context, it.toString(), currentLine, position)
+                                DebugLogger.log("Saving bookmark at line $currentLine")
+                                BookmarkManager.save(context, it.toString(), currentLine)
                                 val project = Project(
                                     uri = it.toString(),
                                     name = projectName,
@@ -292,12 +290,16 @@ fun BookScreen(
                                     weights = weights,
                                     mode = interpolationMode,
                                     speed = speed,
-                                    bookmark = Bookmark(currentLine, position),
+                                    bookmark = Bookmark(currentLine),
                                     usePregenerated = usePregenerated
                                 )
                                 ProjectManager.save(context, project)
+                                bookmark = Bookmark(currentLine)
                             }
                         } else {
+                            if (playerState == PlayerState.PAUSED) {
+                                bookViewModel.audioPlayer.stop()
+                            }
                             bookViewModel.startPlayback(
                                 session = session,
                                 phonemeConverter = phonemeConverter,
@@ -310,7 +312,6 @@ fun BookScreen(
                                 startLine = currentLine.coerceAtLeast(0),
                                 bookUri = bookUri,
                                 context = context,
-                                bookmark = bookmark,
                                 usePregenerated = usePregenerated,
                                 onFinished = {
                                     bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
@@ -464,26 +465,29 @@ fun BookScreen(
                     .fillMaxWidth()
                     .combinedClickable(
                         onClick = {
-                            bookViewModel.setCurrentLine(index)
-                            bookViewModel.startPlayback(
-                                session = session,
-                                phonemeConverter = phonemeConverter,
-                                styleLoader = styleLoader,
-                                selectedStyles = selectedStyles,
-                                weights = weights,
-                                mode = interpolationMode,
-                                speed = speed,
-                                lines = lines,
-                                startLine = index,
-                                bookUri = bookUri,
-                                context = context,
-                                bookmark = bookmark,
-                                usePregenerated = usePregenerated,
-                                onFinished = {
-                                    bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
-                                    bookmark = null
-                                },
-                            )
+                            if (selectedLines.contains(index)) {
+                                selectedLines.remove(index)
+                            } else {
+                                bookViewModel.setCurrentLine(index)
+                                bookViewModel.startPlayback(
+                                    session = session,
+                                    phonemeConverter = phonemeConverter,
+                                    styleLoader = styleLoader,
+                                    selectedStyles = selectedStyles,
+                                    weights = weights,
+                                    mode = interpolationMode,
+                                    speed = speed,
+                                    lines = lines,
+                                    startLine = index,
+                                    bookUri = bookUri,
+                                    context = context,
+                                    usePregenerated = usePregenerated,
+                                    onFinished = {
+                                        bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
+                                        bookmark = null
+                                    },
+                                )
+                            }
                         },
                         onLongClick = {
                             if (selectedLines.contains(index)) {

--- a/app/src/main/java/com/example/kokoro82m/utils/BookPlayer.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/BookPlayer.kt
@@ -28,7 +28,6 @@ fun playBook(
     context: Context,
     onLineChanged: (Int) -> Unit,
     onFinished: () -> Unit,
-    bookmark: Bookmark?,
     usePregenerated: Boolean,
 ): Job {
     return scope.launch(Dispatchers.IO) {
@@ -83,10 +82,9 @@ fun playBook(
                 withContext(Dispatchers.Main) {
                     onLineChanged(index)
                 }
-                val position = if (index == bookmark?.line) bookmark.position else 0
-                DebugLogger.log("Playing line $index with position $position")
+                DebugLogger.log("Playing line $index")
 
-                audioPlayer.prepare(audio, position)
+                audioPlayer.prepare(audio, 0)
                 audioPlayer.playBlocking()
 
                 if (audioPlayer.getState() == PlayerState.PAUSED) {

--- a/app/src/main/java/com/example/kokoro82m/utils/Bookmark.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/Bookmark.kt
@@ -1,3 +1,3 @@
 package com.example.kokoro82m.utils
 
-data class Bookmark(val line: Int, val position: Int)
+data class Bookmark(val line: Int)

--- a/app/src/main/java/com/example/kokoro82m/utils/BookmarkManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/BookmarkManager.kt
@@ -3,8 +3,8 @@ package com.example.kokoro82m.utils
 import android.content.Context
 
 object BookmarkManager {
-    fun save(context: Context, uri: String, line: Int, position: Int) {
-        DatabaseManager.setBookmark(context, uri, line, position)
+    fun save(context: Context, uri: String, line: Int) {
+        DatabaseManager.setBookmark(context, uri, line)
     }
 
     fun load(context: Context, uri: String): Bookmark? {

--- a/app/src/main/java/com/example/kokoro82m/utils/DatabaseHelper.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/DatabaseHelper.kt
@@ -8,7 +8,7 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME
 
     companion object {
         private const val DATABASE_NAME = "kokoro.db"
-        private const val DATABASE_VERSION = 3
+        private const val DATABASE_VERSION = 4
         const val TABLE_PROJECTS = "projects"
         const val COLUMN_ID = "_id"
         const val COLUMN_URI = "uri"
@@ -18,7 +18,6 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME
         const val COLUMN_MODE = "mode"
         const val COLUMN_SPEED = "speed"
         const val COLUMN_BOOKMARK_LINE = "bookmark_line"
-        const val COLUMN_BOOKMARK_POSITION = "bookmark_position"
         const val COLUMN_AUDIO_PATH = "audio_path"
         const val COLUMN_USE_PREGENERATED = "use_pregenerated"
 
@@ -41,7 +40,6 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME
                 "$COLUMN_MODE TEXT," +
                 "$COLUMN_SPEED REAL," +
                 "$COLUMN_BOOKMARK_LINE INTEGER," +
-                "$COLUMN_BOOKMARK_POSITION INTEGER," +
                 "$COLUMN_AUDIO_PATH TEXT," +
                 "$COLUMN_USE_PREGENERATED INTEGER)"
         db.execSQL(createProjectsTable)

--- a/app/src/main/java/com/example/kokoro82m/utils/DatabaseManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/DatabaseManager.kt
@@ -25,8 +25,7 @@ object DatabaseManager {
             project.audioPath?.let { put(DatabaseHelper.COLUMN_AUDIO_PATH, it) }
             project.bookmark?.let {
                 put(DatabaseHelper.COLUMN_BOOKMARK_LINE, it.line)
-                put(DatabaseHelper.COLUMN_BOOKMARK_POSITION, it.position)
-            }
+            } ?: put(DatabaseHelper.COLUMN_BOOKMARK_LINE, -1)
         }
 
         db.replace(DatabaseHelper.TABLE_PROJECTS, null, values)
@@ -59,8 +58,7 @@ object DatabaseManager {
             val mode = InterpolationMode.valueOf(cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_MODE)))
             val speed = cursor.getFloat(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_SPEED))
             val bookmarkLine = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_BOOKMARK_LINE))
-            val bookmarkPosition = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_BOOKMARK_POSITION))
-            val bookmark = if (bookmarkLine != -1) Bookmark(bookmarkLine, bookmarkPosition) else null
+            val bookmark = if (bookmarkLine != -1) Bookmark(bookmarkLine) else null
             val audioPathIndex = cursor.getColumnIndex(DatabaseHelper.COLUMN_AUDIO_PATH)
             val audioPath = if (audioPathIndex != -1) cursor.getString(audioPathIndex) else null
             val usePregeneratedIdx = cursor.getColumnIndex(DatabaseHelper.COLUMN_USE_PREGENERATED)
@@ -92,8 +90,7 @@ object DatabaseManager {
             val mode = InterpolationMode.valueOf(cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_MODE)))
             val speed = cursor.getFloat(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_SPEED))
             val bookmarkLine = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_BOOKMARK_LINE))
-            val bookmarkPosition = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_BOOKMARK_POSITION))
-            val bookmark = if (bookmarkLine != -1) Bookmark(bookmarkLine, bookmarkPosition) else null
+            val bookmark = if (bookmarkLine != -1) Bookmark(bookmarkLine) else null
             val audioPathIndex = cursor.getColumnIndex(DatabaseHelper.COLUMN_AUDIO_PATH)
             val audioPath = if (audioPathIndex != -1) cursor.getString(audioPathIndex) else null
             val usePregeneratedIdx = cursor.getColumnIndex(DatabaseHelper.COLUMN_USE_PREGENERATED)
@@ -117,12 +114,11 @@ object DatabaseManager {
         }
     }
 
-    fun setBookmark(context: Context, uri: String, line: Int, position: Int) {
+    fun setBookmark(context: Context, uri: String, line: Int) {
         val dbHelper = DatabaseHelper(context)
         val db = dbHelper.writableDatabase
         val values = ContentValues().apply {
             put(DatabaseHelper.COLUMN_BOOKMARK_LINE, line)
-            put(DatabaseHelper.COLUMN_BOOKMARK_POSITION, position)
         }
         db.update(DatabaseHelper.TABLE_PROJECTS, values, "${DatabaseHelper.COLUMN_URI} = ?", arrayOf(uri))
         db.close()
@@ -133,7 +129,7 @@ object DatabaseManager {
         val db = dbHelper.readableDatabase
         val cursor = db.query(
             DatabaseHelper.TABLE_PROJECTS,
-            arrayOf(DatabaseHelper.COLUMN_BOOKMARK_LINE, DatabaseHelper.COLUMN_BOOKMARK_POSITION),
+            arrayOf(DatabaseHelper.COLUMN_BOOKMARK_LINE),
             "${DatabaseHelper.COLUMN_URI} = ?",
             arrayOf(uri),
             null,
@@ -144,9 +140,8 @@ object DatabaseManager {
         var bookmark: Bookmark? = null
         if (cursor.moveToFirst()) {
             val bookmarkLine = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_BOOKMARK_LINE))
-            val bookmarkPosition = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_BOOKMARK_POSITION))
             if (bookmarkLine != -1) {
-                bookmark = Bookmark(bookmarkLine, bookmarkPosition)
+                bookmark = Bookmark(bookmarkLine)
             }
         }
 
@@ -160,7 +155,6 @@ object DatabaseManager {
         val db = dbHelper.writableDatabase
         val values = ContentValues().apply {
             put(DatabaseHelper.COLUMN_BOOKMARK_LINE, -1)
-            put(DatabaseHelper.COLUMN_BOOKMARK_POSITION, -1)
         }
         db.update(DatabaseHelper.TABLE_PROJECTS, values, "${DatabaseHelper.COLUMN_URI} = ?", arrayOf(uri))
         db.close()

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ai.onnxruntime.OrtSession
 import com.example.kokoro82m.utils.AudioPlayer
-import com.example.kokoro82m.utils.Bookmark
 import com.example.kokoro82m.utils.InterpolationMode
 import com.example.kokoro82m.utils.PhonemeConverter
 import com.example.kokoro82m.utils.PlayerState
@@ -69,7 +68,6 @@ class BookViewModel : ViewModel() {
         startLine: Int,
         bookUri: Uri?,
         context: Context,
-        bookmark: Bookmark?,
         usePregenerated: Boolean,
         onFinished: () -> Unit,
     ) {
@@ -90,7 +88,6 @@ class BookViewModel : ViewModel() {
             context = context,
             onLineChanged = { setCurrentLine(it) },
             onFinished = onFinished,
-            bookmark = bookmark,
             usePregenerated = usePregenerated,
         )
     }

--- a/app/src/test/java/com/example/kokoro82m/BookmarkManagerTest.kt
+++ b/app/src/test/java/com/example/kokoro82m/BookmarkManagerTest.kt
@@ -13,11 +13,11 @@ class BookmarkManagerTest {
     @Test
     fun saveLoadAndClearBookmark() {
         val uri = "sample"
-        val bookmark = Bookmark(5, 100)
+        val bookmark = Bookmark(5)
         mockStatic(DatabaseManager::class.java).use { db ->
             db.`when`<Bookmark?> { DatabaseManager.getBookmark(context, uri) }.thenReturn(bookmark)
-            BookmarkManager.save(context, uri, 5, 100)
-            db.verify { BookmarkManager.save(context, uri, 5, 100) }
+            BookmarkManager.save(context, uri, 5)
+            db.verify { DatabaseManager.setBookmark(context, uri, 5) }
             assertEquals(bookmark, BookmarkManager.load(context, uri))
 
             db.`when`<Bookmark?> { DatabaseManager.getBookmark(context, uri) }.thenReturn(null)


### PR DESCRIPTION
## Summary
- Allow tapping a selected line to unselect it while retaining long-press selection
- Store bookmarks by line only and resume playback from the start of the bookmarked line
- Simplify database schema and playback logic for line-based pause/resume

## Testing
- `gradle test` *(fails: SDK packages not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688fe07d4df08331b1b251b6ed14969e