### PR TITLE
Add credits for TensorFlow Lite and ONNX runtime

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/screens/AboutScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/AboutScreen.kt
@@ -81,6 +81,22 @@ fun Acknowledgements() {
             context = context
         )
 
+        Spacer(modifier = Modifier.height(2.dp))
+
+        ClickableLink(
+            text = "TensorFlow Lite: efficient on-device AI (Apache 2.0)",
+            url = "https://github.com/google-ai-edge",
+            context = context
+        )
+
+        Spacer(modifier = Modifier.height(2.dp))
+
+        ClickableLink(
+            text = "Kokoro-82M-Android: Java/Android ONNX Runtime (MIT)",
+            url = "https://github.com/puff-dayo/Kokoro-82M-Android",
+            context = context
+        )
+
     }
 }
 


### PR DESCRIPTION
## Summary
- credit Google AI Edge's TensorFlow Lite project
- thank the Kokoro-82M-Android repo for its ONNX Runtime implementation

## Testing
- `gradle :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891288ff4c08331968024951ab9d7a1