### PR TITLE
Unify Material3 styling and make playback notification clickable

### DIFF
--- a/app-chat/src/main/java/com/example/kokoro/chat/ChatScreen.kt
+++ b/app-chat/src/main/java/com/example/kokoro/chat/ChatScreen.kt
@@ -1,5 +1,6 @@
 package com.example.kokoro.chat
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,10 +12,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.animateItemPlacement
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -63,6 +66,7 @@ fun ChatScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
                 .padding(paddingValues)
         ) {
             LazyColumn(
@@ -72,7 +76,10 @@ fun ChatScreen(
                 reverseLayout = true
             ) {
                 items(chatState.reversed()) { chatMessage ->
-                    MessageBubble(chatMessage)
+                    MessageBubble(
+                        chatMessage,
+                        modifier = Modifier.animateItemPlacement()
+                    )
                     Spacer(modifier = Modifier.height(8.dp))
                 }
             }
@@ -111,7 +118,7 @@ fun ChatScreen(
                     },
                     enabled = message.isNotBlank() && !isLoading
                 ) {
-                    Text("Send")
+                    Icon(Icons.Filled.Send, contentDescription = "Send")
                 }
             }
         }
@@ -119,9 +126,9 @@ fun ChatScreen(
 }
 
 @Composable
-fun MessageBubble(chatMessage: ChatMessage) {
+fun MessageBubble(chatMessage: ChatMessage, modifier: Modifier = Modifier) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         horizontalArrangement = if (chatMessage.isFromUser) Arrangement.End else Arrangement.Start
     ) {
         Card(

--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -12,6 +12,7 @@ import ai.onnxruntime.OrtSession
 import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -115,10 +116,18 @@ private fun showPlaybackNotification(context: Context) {
         manager.createNotificationChannel(channel)
     }
 
+    val contentIntent = PendingIntent.getActivity(
+        context,
+        0,
+        Intent(context, MainActivity::class.java),
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
+
     val notification = NotificationCompat.Builder(context, PLAYBACK_CHANNEL_ID)
         .setSmallIcon(android.R.drawable.ic_media_play)
         .setContentTitle("Playback")
         .setContentText("Audio playback in progress")
+        .setContentIntent(contentIntent)
         .setOngoing(true)
         .build()
 

--- a/app/src/main/java/com/example/kokoro82m/utils/PlaybackNotification.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/PlaybackNotification.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import com.example.kokoro82m.MainActivity
 
 object PlaybackNotification {
     private const val CHANNEL_ID = "book_playback_channel"
@@ -31,12 +32,20 @@ object PlaybackNotification {
         NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID)
     }
 
-    private fun buildNotification(context: Context, playing: Boolean) =
-        NotificationCompat.Builder(context, CHANNEL_ID)
+    private fun buildNotification(context: Context, playing: Boolean): android.app.Notification {
+        val contentIntent = PendingIntent.getActivity(
+            context,
+            0,
+            Intent(context, MainActivity::class.java),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_media_play)
             .setContentTitle("Book Playback")
             .setContentText(if (playing) "Playing" else "Paused")
             .setOngoing(playing)
+            .setContentIntent(contentIntent)
             .addAction(
                 if (playing) android.R.drawable.ic_media_pause else android.R.drawable.ic_media_play,
                 if (playing) "Pause" else "Play",
@@ -49,6 +58,7 @@ object PlaybackNotification {
             )
             .setOnlyAlertOnce(true)
             .build()
+    }
 
     private fun createChannel(context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
## Summary
- unify chat screen with Material 3 color kit and animated message transitions
- use Material icons for send action
- make playback notification open the app when tapped

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891975aaa64833182df0409b7a8f3d3