### PR TITLE
Add selectable TTS engine

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -73,9 +73,11 @@ import com.example.kokoro82m.utils.MainViewModel
 import com.example.kokoro82m.utils.PhonemeConverter
 import com.example.kokoro82m.utils.StyleLoader
 import com.example.kokoro82m.utils.createAudio
+import com.example.kokoro82m.utils.createKittenAudioFromStyleVector
 import com.example.kokoro82m.utils.playAudio
 import com.example.kokoro82m.utils.saveAudio
 import com.example.kokoro82m.utils.SettingsManager
+import com.example.kokoro82m.utils.TtsEngine
 import com.example.kokoro82m.utils.DebugLogger
 import com.google.android.material.color.DynamicColors
 import kotlinx.coroutines.CoroutineScope
@@ -219,14 +221,26 @@ private fun generateAudio(
             }
 
 
+            val engine = SettingsManager.getTtsEngine(context)
             val (audioData, sampleRate) = PerfHud.record("ONNX synth") {
-                createAudio(
-                    voice = style,
-                    phonemes = phonemes,
-                    speed = speed,
-                    context = context,
-                    session = session
-                )
+                if (engine == TtsEngine.KITTEN) {
+                    val loader = StyleLoader(context)
+                    val voiceArray = loader.getStyleArray(style)
+                    createKittenAudioFromStyleVector(
+                        phonemes = phonemes,
+                        voice = voiceArray,
+                        speed = speed,
+                        session = session
+                    )
+                } else {
+                    createAudio(
+                        voice = style,
+                        phonemes = phonemes,
+                        speed = speed,
+                        context = context,
+                        session = session
+                    )
+                }
             }
 
             playAudio(

--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -370,14 +370,24 @@ fun BookScreen(
                                     mode = interpolationMode
                                 )
                                 val audioData = mutableListOf<Float>()
+                                val engine = SettingsManager.getTtsEngine(context)
                                 for (line in lines) {
                                     val phonemes = phonemeConverter.phonemize(line)
-                                    val (audio, _) = createAudioFromStyleVector(
-                                        phonemes = phonemes,
-                                        voice = mixedVector,
-                                        speed = speed,
-                                        session = session
-                                    )
+                                    val (audio, _) = if (engine == TtsEngine.KITTEN) {
+                                        createKittenAudioFromStyleVector(
+                                            phonemes = phonemes,
+                                            voice = mixedVector,
+                                            speed = speed,
+                                            session = session
+                                        )
+                                    } else {
+                                        createAudioFromStyleVector(
+                                            phonemes = phonemes,
+                                            voice = mixedVector,
+                                            speed = speed,
+                                            session = session
+                                        )
+                                    }
                                     audioData.addAll(audio.toList())
                                 }
                                 val fileName = buildStyleFileName(selectedStyles, weights, interpolationMode)
@@ -408,14 +418,24 @@ fun BookScreen(
                                         mode = interpolationMode
                                     )
                                     val audioData = mutableListOf<Float>()
+                                    val engine = SettingsManager.getTtsEngine(context)
                                     for (i in selectedLines.sorted()) {
                                         val phonemes = phonemeConverter.phonemize(lines[i])
-                                        val (audio, _) = createAudioFromStyleVector(
-                                            phonemes = phonemes,
-                                            voice = mixedVector,
-                                            speed = speed,
-                                            session = session
-                                        )
+                                        val (audio, _) = if (engine == TtsEngine.KITTEN) {
+                                            createKittenAudioFromStyleVector(
+                                                phonemes = phonemes,
+                                                voice = mixedVector,
+                                                speed = speed,
+                                                session = session
+                                            )
+                                        } else {
+                                            createAudioFromStyleVector(
+                                                phonemes = phonemes,
+                                                voice = mixedVector,
+                                                speed = speed,
+                                                session = session
+                                            )
+                                        }
                                         audioData.addAll(audio.toList())
                                     }
                                     val fileName = buildStyleFileName(selectedStyles, weights, interpolationMode) + "_clip"

--- a/app/src/main/java/com/example/kokoro82m/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/MixerScreen.kt
@@ -44,10 +44,12 @@ import com.example.kokoro82m.utils.InterpolationMode
 import com.example.kokoro82m.utils.PhonemeConverter
 import com.example.kokoro82m.utils.StyleLoader
 import com.example.kokoro82m.utils.createAudioFromStyleVector
+import com.example.kokoro82m.utils.createKittenAudioFromStyleVector
 import com.example.kokoro82m.utils.mixStyles
 import com.example.kokoro82m.utils.playAudio
 import com.example.kokoro82m.utils.saveAudio
 import com.example.kokoro82m.utils.SettingsManager
+import com.example.kokoro82m.utils.TtsEngine
 import com.example.kokoro82m.utils.DebugLogger
 import com.example.kokoro82m.utils.buildStyleFileName
 import kotlinx.coroutines.Dispatchers
@@ -233,12 +235,22 @@ private fun generateAudio(
     scope.launch(Dispatchers.IO) {
         try {
             val phonemes = phonemeConverter.phonemize(text)
-            val (audio, _) = createAudioFromStyleVector(
-                phonemes = phonemes,
-                voice = style,
-                speed = speed,
-                session = session
-            )
+            val engine = SettingsManager.getTtsEngine(context)
+            val (audio, _) = if (engine == TtsEngine.KITTEN) {
+                createKittenAudioFromStyleVector(
+                    phonemes = phonemes,
+                    voice = style,
+                    speed = speed,
+                    session = session
+                )
+            } else {
+                createAudioFromStyleVector(
+                    phonemes = phonemes,
+                    voice = style,
+                    speed = speed,
+                    session = session
+                )
+            }
             if (shouldSaveFile && fileName != null) {
                 saveAudio(audio, context, fileName)
             }

--- a/app/src/main/java/com/example/kokoro82m/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/SettingsScreen.kt
@@ -3,8 +3,13 @@ package com.example.kokoro82m.screens
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -15,11 +20,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.example.kokoro82m.utils.SettingsManager
+import com.example.kokoro82m.utils.TtsEngine
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen() {
     val context = LocalContext.current
     var debug by remember { mutableStateOf(SettingsManager.isDebug(context)) }
+    var engine by remember { mutableStateOf(SettingsManager.getTtsEngine(context)) }
+    var expanded by remember { mutableStateOf(false) }
 
     Column(modifier = Modifier.padding(16.dp)) {
         androidx.compose.foundation.layout.Row(verticalAlignment = Alignment.CenterVertically) {
@@ -31,6 +40,35 @@ fun SettingsScreen() {
                 }
             )
             Text(text = "Debug Mode", modifier = Modifier.padding(start = 8.dp))
+        }
+
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = it }
+        ) {
+            TextField(
+                value = engine.name,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("TTS Engine") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier.menuAnchor().fillMaxWidth()
+            )
+            androidx.compose.material3.ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false }
+            ) {
+                TtsEngine.values().forEach { option ->
+                    DropdownMenuItem(
+                        text = { Text(option.name) },
+                        onClick = {
+                            engine = option
+                            SettingsManager.setTtsEngine(context, option)
+                            expanded = false
+                        }
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.example.kokoro82m.screens
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -31,7 +32,7 @@ fun SettingsScreen() {
     var expanded by remember { mutableStateOf(false) }
 
     Column(modifier = Modifier.padding(16.dp)) {
-        androidx.compose.foundation.layout.Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
             Switch(
                 checked = debug,
                 onCheckedChange = {
@@ -54,7 +55,7 @@ fun SettingsScreen() {
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
                 modifier = Modifier.menuAnchor().fillMaxWidth()
             )
-            androidx.compose.material3.ExposedDropdownMenu(
+            ExposedDropdownMenu(
                 expanded = expanded,
                 onDismissRequest = { expanded = false }
             ) {

--- a/app/src/main/java/com/example/kokoro82m/utils/AudioPreGenerator.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/AudioPreGenerator.kt
@@ -5,6 +5,9 @@ import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import com.example.kokoro82m.utils.SettingsManager
+import com.example.kokoro82m.utils.TtsEngine
+import com.example.kokoro82m.utils.createKittenAudioFromStyleVector
 
 suspend fun preGenerateBook(
     context: Context,
@@ -29,12 +32,22 @@ suspend fun preGenerateBook(
         if (DatabaseManager.getAudioLine(context, project.uri, index) != null) continue
         DebugLogger.log("Generating line $index for ${project.uri}")
         val phonemes = phonemeConverter.phonemize(line)
-        val (audio, _) = createAudioFromStyleVector(
-            phonemes = phonemes,
-            voice = mixed,
-            speed = project.speed,
-            session = session,
-        )
+        val engine = SettingsManager.getTtsEngine(context)
+        val (audio, _) = if (engine == TtsEngine.KITTEN) {
+            createKittenAudioFromStyleVector(
+                phonemes = phonemes,
+                voice = mixed,
+                speed = project.speed,
+                session = session,
+            )
+        } else {
+            createAudioFromStyleVector(
+                phonemes = phonemes,
+                voice = mixed,
+                speed = project.speed,
+                session = session,
+            )
+        }
         val file = File(baseDir, "$index.wav")
         saveAudioInternal(audio, file)
         DatabaseManager.setAudioLine(context, project.uri, index, file.absolutePath)

--- a/app/src/main/java/com/example/kokoro82m/utils/BookPlayer.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/BookPlayer.kt
@@ -11,6 +11,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.channels.Channel
 import java.io.File
+import com.example.kokoro82m.utils.createKittenAudioFromStyleVector
+import com.example.kokoro82m.utils.SettingsManager
+import com.example.kokoro82m.utils.TtsEngine
 
 fun playBook(
     scope: CoroutineScope,
@@ -56,12 +59,22 @@ fun playBook(
                     }
                     val line = lines[index]
                     val phonemes = phonemeConverter.phonemize(line)
-                    val (audio, _) = createAudioFromStyleVector(
-                        phonemes = phonemes,
-                        voice = mixedVector,
-                        speed = speed,
-                        session = session,
-                    )
+                    val engine = SettingsManager.getTtsEngine(context)
+                    val (audio, _) = if (engine == TtsEngine.KITTEN) {
+                        createKittenAudioFromStyleVector(
+                            phonemes = phonemes,
+                            voice = mixedVector,
+                            speed = speed,
+                            session = session,
+                        )
+                    } else {
+                        createAudioFromStyleVector(
+                            phonemes = phonemes,
+                            voice = mixedVector,
+                            speed = speed,
+                            session = session,
+                        )
+                    }
                     audioBuffer.send(Pair(audio, index))
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/com/example/kokoro82m/utils/CreateAudio.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/CreateAudio.kt
@@ -100,3 +100,45 @@ fun createAudioFromStyleVector(
 
     return Pair(audioTensor, SAMPLE_RATE)
 }
+
+fun createKittenAudioFromStyleVector(
+    phonemes: String,
+    voice: Array<FloatArray>,
+    speed: Float,
+    session: OrtSession,
+): Pair<FloatArray, Int> {
+    val MAX_PHONEME_LENGTH = 400
+    val SAMPLE_RATE = 24000
+
+    val truncatedPhonemes = phonemes.take(MAX_PHONEME_LENGTH)
+    val tokens = Tokenizer.tokenize(truncatedPhonemes)
+    val paddedTokens = listOf(0L) + tokens.toList() + listOf(0L)
+
+    val tokenTensor = OnnxTensor.createTensor(
+        OrtEnvironment.getEnvironment(),
+        arrayOf(paddedTokens.toLongArray())
+    )
+    val styleTensor = OnnxTensor.createTensor(
+        OrtEnvironment.getEnvironment(),
+        voice
+    )
+    val speedTensor = OnnxTensor.createTensor(
+        OrtEnvironment.getEnvironment(),
+        floatArrayOf(speed)
+    )
+
+    val inputs = mapOf(
+        "input_ids" to tokenTensor,
+        "style" to styleTensor,
+        "speed" to speedTensor
+    )
+    val results = session.run(inputs)
+    val audioTensor = results[0].value as FloatArray
+    results.close()
+
+    val start = 5000
+    val end = if (audioTensor.size > 10000) audioTensor.size - 10000 else audioTensor.size
+    val trimmed = audioTensor.copyOfRange(start, end)
+
+    return Pair(trimmed, SAMPLE_RATE)
+}

--- a/app/src/main/java/com/example/kokoro82m/utils/SettingsManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/SettingsManager.kt
@@ -23,4 +23,13 @@ object SettingsManager {
 
     fun getSpeed(context: Context, default: Float = 1.0f): Float =
         DatabaseManager.getSetting(context, "speed")?.toFloat() ?: default
+
+    fun setTtsEngine(context: Context, engine: TtsEngine) {
+        DatabaseManager.setSetting(context, "tts_engine", engine.name)
+    }
+
+    fun getTtsEngine(context: Context, default: TtsEngine = TtsEngine.KOKORO): TtsEngine =
+        DatabaseManager.getSetting(context, "tts_engine")?.let {
+            runCatching { TtsEngine.valueOf(it) }.getOrNull()
+        } ?: default
 }

--- a/app/src/main/java/com/example/kokoro82m/utils/TtsEngine.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/TtsEngine.kt
@@ -1,0 +1,6 @@
+package com.example.kokoro82m.utils
+
+enum class TtsEngine {
+    KOKORO,
+    KITTEN
+}

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
@@ -13,6 +13,9 @@ import com.example.kokoro82m.utils.PlayerState
 import com.example.kokoro82m.utils.StyleLoader
 import com.example.kokoro82m.utils.DebugLogger
 import com.example.kokoro82m.utils.createAudioFromStyleVector
+import com.example.kokoro82m.utils.createKittenAudioFromStyleVector
+import com.example.kokoro82m.utils.SettingsManager
+import com.example.kokoro82m.utils.TtsEngine
 import com.example.kokoro82m.utils.mixStyles
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -143,13 +146,22 @@ class ChatTtsViewModel(
                         _interpolationMode.value
                     )
                     val phonemes = phonemeConverter.phonemize(text)
-
-                    val (data, _) = createAudioFromStyleVector(
-                        phonemes = phonemes,
-                        voice = mixedVector,
-                        speed = _speed.value,
-                        session = ortSession
-                    )
+                    val engine = SettingsManager.getTtsEngine(context)
+                    val (data, _) = if (engine == TtsEngine.KITTEN) {
+                        createKittenAudioFromStyleVector(
+                            phonemes = phonemes,
+                            voice = mixedVector,
+                            speed = _speed.value,
+                            session = ortSession
+                        )
+                    } else {
+                        createAudioFromStyleVector(
+                            phonemes = phonemes,
+                            voice = mixedVector,
+                            speed = _speed.value,
+                            session = ortSession
+                        )
+                    }
                     data
                 }
                 audioQueue.send(audioData)


### PR DESCRIPTION
## Summary
- allow choosing Kokoro or Kitten TTS engines
- add engine selector to settings screen
- route basic, book, chat and mixer synthesis through selected engine

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68931551e4c08331a4692a3c123a560a