### PR TITLE
fix: align kitten inference input names

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/utils/CreateAudio.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/CreateAudio.kt
@@ -44,7 +44,7 @@ fun createAudio(
     )
 
     val inputs = mapOf(
-        "tokens" to tokenTensor,
+        "input_ids" to tokenTensor,
         "style" to styleTensor,
         "speed" to speedTensor
     )
@@ -90,7 +90,7 @@ fun createAudioFromStyleVector(
     )
 
     val inputs = mapOf(
-        "tokens" to tokenTensor,
+        "input_ids" to tokenTensor,
         "style" to styleTensor,
         "speed" to speedTensor
     )
@@ -128,7 +128,7 @@ fun createKittenAudioFromStyleVector(
     )
 
     val inputs = mapOf(
-        "tokens" to tokenTensor,
+        "input_ids" to tokenTensor,
         "style" to styleTensor,
         "speed" to speedTensor
     )


### PR DESCRIPTION
## Summary
- send token tensor under `input_ids` to match Kitten TTS ONNX model

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6893a7512d488331ae12845a549b9701