### PR TITLE
Add Kitten phonemizer matching Python pipeline

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -74,6 +74,7 @@ import com.example.kokoro82m.utils.PhonemeConverter
 import com.example.kokoro82m.utils.StyleLoader
 import com.example.kokoro82m.utils.createAudio
 import com.example.kokoro82m.utils.createKittenAudioFromStyleVector
+import com.example.kokoro82m.utils.KittenPhonemizer
 import com.example.kokoro82m.utils.playAudio
 import com.example.kokoro82m.utils.saveAudio
 import com.example.kokoro82m.utils.SettingsManager
@@ -214,25 +215,28 @@ private fun generateAudio(
 ) {
     scope.launch(Dispatchers.IO) {
         try {
-            val phonemes = phonemeConverter.phonemize(text)
-            DebugLogger.log("Phonemes: $phonemes")
-            withContext(Dispatchers.Main) {
-                Toast.makeText(context, "Phonemes: $phonemes", Toast.LENGTH_LONG).show()
-            }
-
-
             val engine = SettingsManager.getTtsEngine(context)
             val (audioData, sampleRate) = PerfHud.record("ONNX synth") {
                 if (engine == TtsEngine.KITTEN) {
+                    val (phonemeStr, tokens) = KittenPhonemizer.phonemize(text)
+                    DebugLogger.log("Phonemes: $phonemeStr")
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(context, "Phonemes: $phonemeStr", Toast.LENGTH_LONG).show()
+                    }
                     val loader = StyleLoader(context)
                     val voiceArray = loader.getStyleArray(style)
                     createKittenAudioFromStyleVector(
-                        phonemes = phonemes,
+                        tokens = tokens,
                         voice = voiceArray,
                         speed = speed,
                         session = session
                     )
                 } else {
+                    val phonemes = phonemeConverter.phonemize(text)
+                    DebugLogger.log("Phonemes: $phonemes")
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(context, "Phonemes: $phonemes", Toast.LENGTH_LONG).show()
+                    }
                     createAudio(
                         voice = style,
                         phonemes = phonemes,

--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -375,15 +375,16 @@ fun BookScreen(
                                 val engine = SettingsManager.getTtsEngine(context)
                                 val sampleRate = if (engine == TtsEngine.KITTEN) 24000 else 22050
                                 for (line in lines) {
-                                    val phonemes = phonemeConverter.phonemize(line)
                                     val (audio, _) = if (engine == TtsEngine.KITTEN) {
+                                        val (_, tokens) = KittenPhonemizer.phonemize(line)
                                         createKittenAudioFromStyleVector(
-                                            phonemes = phonemes,
+                                            tokens = tokens,
                                             voice = mixedVector,
                                             speed = speed,
                                             session = session
                                         )
                                     } else {
+                                        val phonemes = phonemeConverter.phonemize(line)
                                         createAudioFromStyleVector(
                                             phonemes = phonemes,
                                             voice = mixedVector,
@@ -424,15 +425,16 @@ fun BookScreen(
                                     val engine = SettingsManager.getTtsEngine(context)
                                     val sampleRate = if (engine == TtsEngine.KITTEN) 24000 else 22050
                                     for (i in selectedLines.sorted()) {
-                                        val phonemes = phonemeConverter.phonemize(lines[i])
                                         val (audio, _) = if (engine == TtsEngine.KITTEN) {
+                                            val (_, tokens) = KittenPhonemizer.phonemize(lines[i])
                                             createKittenAudioFromStyleVector(
-                                                phonemes = phonemes,
+                                                tokens = tokens,
                                                 voice = mixedVector,
                                                 speed = speed,
                                                 session = session
                                             )
                                         } else {
+                                            val phonemes = phonemeConverter.phonemize(lines[i])
                                             createAudioFromStyleVector(
                                                 phonemes = phonemes,
                                                 voice = mixedVector,

--- a/app/src/main/java/com/example/kokoro82m/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/MixerScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.example.kokoro82m.utils.InterpolationMode
 import com.example.kokoro82m.utils.PhonemeConverter
+import com.example.kokoro82m.utils.KittenPhonemizer
 import com.example.kokoro82m.utils.StyleLoader
 import com.example.kokoro82m.utils.createAudioFromStyleVector
 import com.example.kokoro82m.utils.createKittenAudioFromStyleVector
@@ -235,16 +236,17 @@ private fun generateAudio(
 ) {
     scope.launch(Dispatchers.IO) {
         try {
-            val phonemes = phonemeConverter.phonemize(text)
             val engine = SettingsManager.getTtsEngine(context)
             val (audio, sampleRate) = if (engine == TtsEngine.KITTEN) {
+                val (_, tokens) = KittenPhonemizer.phonemize(text)
                 createKittenAudioFromStyleVector(
-                    phonemes = phonemes,
+                    tokens = tokens,
                     voice = style,
                     speed = speed,
                     session = session
                 )
             } else {
+                val phonemes = phonemeConverter.phonemize(text)
                 createAudioFromStyleVector(
                     phonemes = phonemes,
                     voice = style,

--- a/app/src/main/java/com/example/kokoro82m/utils/AudioPreGenerator.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/AudioPreGenerator.kt
@@ -8,6 +8,7 @@ import java.io.File
 import com.example.kokoro82m.utils.SettingsManager
 import com.example.kokoro82m.utils.TtsEngine
 import com.example.kokoro82m.utils.createKittenAudioFromStyleVector
+import com.example.kokoro82m.utils.KittenPhonemizer
 
 suspend fun preGenerateBook(
     context: Context,
@@ -31,16 +32,17 @@ suspend fun preGenerateBook(
     for ((index, line) in lines.withIndex()) {
         if (DatabaseManager.getAudioLine(context, project.uri, index) != null) continue
         DebugLogger.log("Generating line $index for ${project.uri}")
-        val phonemes = phonemeConverter.phonemize(line)
         val engine = SettingsManager.getTtsEngine(context)
         val (audio, sampleRate) = if (engine == TtsEngine.KITTEN) {
+            val (_, tokens) = KittenPhonemizer.phonemize(line)
             createKittenAudioFromStyleVector(
-                phonemes = phonemes,
+                tokens = tokens,
                 voice = mixed,
                 speed = project.speed,
                 session = session,
             )
         } else {
+            val phonemes = phonemeConverter.phonemize(line)
             createAudioFromStyleVector(
                 phonemes = phonemes,
                 voice = mixed,

--- a/app/src/main/java/com/example/kokoro82m/utils/BookPlayer.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/BookPlayer.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.channels.Channel
 import java.io.File
 import com.example.kokoro82m.utils.createKittenAudioFromStyleVector
+import com.example.kokoro82m.utils.KittenPhonemizer
 import com.example.kokoro82m.utils.SettingsManager
 import com.example.kokoro82m.utils.TtsEngine
 
@@ -58,16 +59,17 @@ fun playBook(
                         }
                     }
                     val line = lines[index]
-                    val phonemes = phonemeConverter.phonemize(line)
                     val engine = SettingsManager.getTtsEngine(context)
                     val (audio, _) = if (engine == TtsEngine.KITTEN) {
+                        val (_, tokens) = KittenPhonemizer.phonemize(line)
                         createKittenAudioFromStyleVector(
-                            phonemes = phonemes,
+                            tokens = tokens,
                             voice = mixedVector,
                             speed = speed,
                             session = session,
                         )
                     } else {
+                        val phonemes = phonemeConverter.phonemize(line)
                         createAudioFromStyleVector(
                             phonemes = phonemes,
                             voice = mixedVector,

--- a/app/src/main/java/com/example/kokoro82m/utils/CreateAudio.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/CreateAudio.kt
@@ -102,21 +102,16 @@ fun createAudioFromStyleVector(
 }
 
 fun createKittenAudioFromStyleVector(
-    phonemes: String,
+    tokens: LongArray,
     voice: Array<FloatArray>,
     speed: Float,
     session: OrtSession,
 ): Pair<FloatArray, Int> {
-    val MAX_PHONEME_LENGTH = 400
     val SAMPLE_RATE = 24000
-
-    val truncatedPhonemes = phonemes.take(MAX_PHONEME_LENGTH)
-    val tokens = Tokenizer.tokenize(truncatedPhonemes)
-    val paddedTokens = listOf(0L) + tokens.toList() + listOf(0L)
 
     val tokenTensor = OnnxTensor.createTensor(
         OrtEnvironment.getEnvironment(),
-        arrayOf(paddedTokens.toLongArray())
+        arrayOf(tokens)
     )
     val styleTensor = OnnxTensor.createTensor(
         OrtEnvironment.getEnvironment(),

--- a/app/src/main/java/com/example/kokoro82m/utils/KittenPhonemizer.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/KittenPhonemizer.kt
@@ -1,0 +1,44 @@
+package com.example.kokoro82m.utils
+
+import com.github.medavox.ipa_transcribers.Language
+
+object KittenPhonemizer {
+    private const val MAX_PHONEME_LENGTH = 400
+
+    private val VOCAB: Map<Char, Int>
+    private val transcriber = Language.ENGLISH.transcriber
+
+    init {
+        val pad = '$'
+        val punctuation = ";:,.!?¡¿—…\"«»“” "
+        val letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+        val lettersIpa = "ɑɐɒæɓʙβɔɕçɗɖðʤəɘɚɛɜɝɞɟʄɡɠɢʛɦɧħɥʜɨɪʝɭɬɫɮʟɱɯɰŋɳɲɴøɵɸθœɶʘɹɺɾɻʀʁɽʂʃʈʧʉʊʋⱱʌɣɤʍχʎʏʑʐʒʔʡʕʢǀǁǂǃˈˌːˑʼʴʰʱʲʷˠˤ˞↓↑→↗↘'̩'ᵻ"
+        val symbols = listOf(pad) + punctuation.toList() + letters.toList() + lettersIpa.toList()
+        VOCAB = symbols.withIndex().associate { (index, char) -> char to index }
+    }
+
+    private fun getPhonemesLikeEspeak(text: String): String {
+        var ipa = transcriber.transcribe(text)
+        val replacements = listOf(
+            "r" to "ɹ",
+            "ɫ" to "l"
+        )
+        replacements.forEach { (from, to) -> ipa = ipa.replace(from, to) }
+        ipa = ipa.replace("\\s+".toRegex(), " ").trim()
+        return ipa
+    }
+
+    fun phonemize(text: String): Pair<String, LongArray> {
+        val phonemeStr = getPhonemesLikeEspeak(text)
+        val truncated = phonemeStr.take(MAX_PHONEME_LENGTH)
+        val tokens = truncated.map { ch ->
+            VOCAB[ch] ?: throw IllegalArgumentException("Kitten TTS: Unknown symbol '$ch'")
+        }
+        val padded = LongArray(tokens.size + 2)
+        padded[0] = 0L
+        tokens.forEachIndexed { index, value -> padded[index + 1] = value.toLong() }
+        padded[padded.size - 1] = 0L
+        return Pair(truncated, padded)
+    }
+}
+

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
@@ -9,6 +9,7 @@ import com.example.kokoro.chat.LlmInference
 import com.example.kokoro82m.utils.AudioPlayer
 import com.example.kokoro82m.utils.InterpolationMode
 import com.example.kokoro82m.utils.KittenAudioPlayer
+import com.example.kokoro82m.utils.KittenPhonemizer
 import com.example.kokoro82m.utils.KokoroAudioPlayer
 import com.example.kokoro82m.utils.PhonemeConverter
 import com.example.kokoro82m.utils.PlayerState
@@ -153,16 +154,17 @@ class ChatTtsViewModel(
                         _weights.value,
                         _interpolationMode.value
                     )
-                    val phonemes = phonemeConverter.phonemize(text)
                     val engine = SettingsManager.getTtsEngine(context)
                     val (data, _) = if (engine == TtsEngine.KITTEN) {
+                        val (_, tokens) = KittenPhonemizer.phonemize(text)
                         createKittenAudioFromStyleVector(
-                            phonemes = phonemes,
+                            tokens = tokens,
                             voice = mixedVector,
                             speed = _speed.value,
                             session = ortSession
                         )
                     } else {
+                        val phonemes = phonemeConverter.phonemize(text)
                         createAudioFromStyleVector(
                             phonemes = phonemes,
                             voice = mixedVector,


### PR DESCRIPTION
## Summary
- add KittenPhonemizer with espeak-style vocab and token padding
- update Kitten audio generation to consume pretokenized input
- switch Kitten call sites to use new phonemizer

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893ba43c75483318793847847a19c1b