### PR TITLE
Load Kitten ONNX model when Kitten TTS engine is active

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ android {
 dependencies {
     implementation(project(":app-chat"))
     implementation(project(":core-utils"))
+    implementation(project(":app-tts"))
     implementation("com.google.ai.edge.litert:litert:1.0.1")
     runtimeOnly("com.google.ai.edge.litert:litert-gpu:1.0.1")
     implementation("com.google.mediapipe:tasks-core:latest.release")

--- a/app/src/main/java/com/example/kokoro82m/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/SettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
@@ -22,6 +23,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.example.kokoro82m.utils.SettingsManager
 import com.example.kokoro82m.utils.TtsEngine
+import com.example.kokoro82m.utils.OnnxRuntimeManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -30,6 +34,12 @@ fun SettingsScreen() {
     var debug by remember { mutableStateOf(SettingsManager.isDebug(context)) }
     var engine by remember { mutableStateOf(SettingsManager.getTtsEngine(context)) }
     var expanded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(engine) {
+        withContext(Dispatchers.IO) {
+            OnnxRuntimeManager.initialize(context.applicationContext)
+        }
+    }
 
     Column(modifier = Modifier.padding(16.dp)) {
         Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/com/example/kokoro82m/utils/OnnxRuntimeManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/OnnxRuntimeManager.kt
@@ -35,6 +35,7 @@ object OnnxRuntimeManager {
         if (environment == null) {
             environment = OrtEnvironment.getEnvironment()
         }
+        session?.close()
         session = if (modelPath != null) {
             createSession(modelPath)
         } else {
@@ -57,8 +58,13 @@ object OnnxRuntimeManager {
             addConfigEntry("nnapi.gpu_precision_loss_allowed", "true")
         }
 
-        return context.resources.openRawResource(R.raw.kokoro).use { stream ->
-            environment!!.createSession(stream.readBytes(), options)
+        return when (SettingsManager.getTtsEngine(context)) {
+            TtsEngine.KOKORO -> context.resources.openRawResource(R.raw.kokoro).use { stream ->
+                environment!!.createSession(stream.readBytes(), options)
+            }
+            TtsEngine.KITTEN -> context.assets.open("kitten_tts/kitten_tts_nano_v0_1.onnx").use { stream ->
+                environment!!.createSession(stream.readBytes(), options)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- load engine-specific ONNX model via OnnxRuntimeManager
- include app-tts module to package Kitten model assets
- reinitialize ONNX session after switching TTS engine in settings

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893de5c38208331884fcb810ea2d936