### PR TITLE
Fix Kitten TTS input name for ONNX runtime

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/utils/CreateAudio.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/CreateAudio.kt
@@ -123,7 +123,7 @@ fun createKittenAudioFromStyleVector(
     )
 
     val inputs = mapOf(
-        "tokens" to tokenTensor,
+        "input_ids" to tokenTensor,
         "style" to styleTensor,
         "speed" to speedTensor
     )


### PR DESCRIPTION
## Summary
- Use correct `input_ids` tensor name when running Kitten TTS ONNX model

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68941097fd8883318089c074ff194e9d