### PR TITLE
Fix mixer using current ORT session

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -384,7 +384,6 @@ fun MainScreen(
             when (currentScreen) {
                 Screen.Basic -> BasicScreen(onGenerateAudio = onGenerateAudio)
                 Screen.Mixer -> MixerScreen(
-                    session = session,
                     phonemeConverter = phonemeConverter,
                     styleLoader = StyleLoader(context)
                 )

--- a/app/src/main/java/com/example/kokoro82m/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/MixerScreen.kt
@@ -1,6 +1,5 @@
 package com.example.kokoro82m.screens
 
-import ai.onnxruntime.OrtSession
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -53,6 +52,7 @@ import com.example.kokoro82m.utils.saveAudio
 import com.example.kokoro82m.utils.SettingsManager
 import com.example.kokoro82m.utils.TtsEngine
 import com.example.kokoro82m.utils.DebugLogger
+import com.example.kokoro82m.utils.OnnxRuntimeManager
 import com.example.kokoro82m.utils.buildStyleFileName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -61,7 +61,6 @@ import kotlinx.coroutines.withContext
 /** Simplified mixer screen showing a static style configuration. */
 @Composable
 fun MixerScreen(
-    session: OrtSession,
     phonemeConverter: PhonemeConverter,
     styleLoader: StyleLoader,
 ) {
@@ -160,7 +159,6 @@ fun MixerScreen(
                             speed,
                             shouldSaveFile,
                             null,
-                            session,
                             phonemeConverter,
                             scope,
                             context
@@ -186,7 +184,6 @@ fun MixerScreen(
                             speed,
                             shouldSaveFile,
                             fileName,
-                            session,
                             phonemeConverter,
                             scope,
                             context
@@ -229,12 +226,12 @@ private fun generateAudio(
     speed: Float,
     shouldSaveFile: Boolean,
     fileName: String?,
-    session: OrtSession,
     phonemeConverter: PhonemeConverter,
     scope: kotlinx.coroutines.CoroutineScope,
     context: android.content.Context,
     onComplete: () -> Unit
 ) {
+    val session = OnnxRuntimeManager.getSession()
     scope.launch(Dispatchers.IO) {
         try {
             val engine = SettingsManager.getTtsEngine(context)


### PR DESCRIPTION
## Summary
- Ensure MixerScreen fetches the ONNX session on demand so it doesn't use a closed session
- Remove session parameter from MixerScreen and stop passing it from MainScreen

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896356c31e48331ab340426ebb4a154