### PR TITLE
feat: centralize debug logging and add dedicated log screen

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -8,6 +8,7 @@ import com.example.kokoro82m.screens.SettingsScreen
 import com.example.kokoro82m.screens.MixerScreen
 import com.example.kokoro82m.screens.MoreScreen
 import com.example.kokoro82m.screens.ModelsScreen
+import com.example.kokoro82m.screens.DebugLogScreen
 import com.example.kokoro.galleryport.PerfHud
 import ai.onnxruntime.OrtSession
 import android.app.Application
@@ -285,6 +286,7 @@ private fun screenFromString(name: String?): Screen = when (name) {
     "Settings" -> Screen.Settings
     "About" -> Screen.About
     "Models" -> Screen.Models
+    "DebugLog" -> Screen.DebugLog
     else -> Screen.Basic
 }
 
@@ -299,6 +301,7 @@ sealed class Screen(val title: String) {
     object Settings : Screen("Settings")
     object About : Screen("About this app")
     object Models : Screen("Models")
+    object DebugLog : Screen("Debug Log")
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -403,6 +406,7 @@ fun MainScreen(
                         "Creations" -> Screen.Creations
                         "Settings" -> Screen.Settings
                         "Models" -> Screen.Models
+                        "DebugLog" -> Screen.DebugLog
                         else -> currentScreen
                     }
                 }
@@ -410,6 +414,7 @@ fun MainScreen(
                 Screen.Settings -> SettingsScreen()
                 Screen.About -> AboutScreen()
                 Screen.Models -> ModelsScreen(userPreferencesRepository)
+                Screen.DebugLog -> DebugLogScreen()
             }
         }
     }

--- a/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/BookScreen.kt
@@ -578,12 +578,7 @@ fun BookScreen(
             }
         }
 
-        item {
-            if (SettingsManager.isDebug(context)) {
-                val logs = DebugLogger.getLogs().joinToString("\n")
-                Text(logs, modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_medium)))
-            }
-        }
+        // Debug logs moved to dedicated screen
     }
 
     if (isPregenerating) {

--- a/app/src/main/java/com/example/kokoro82m/screens/DebugLogScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/DebugLogScreen.kt
@@ -1,0 +1,25 @@
+package com.example.kokoro82m.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.kokoro82m.utils.DebugLogger
+
+@Composable
+fun DebugLogScreen() {
+    val logs = DebugLogger.getLogs().joinToString("\n")
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        Text(text = logs)
+    }
+}

--- a/app/src/main/java/com/example/kokoro82m/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/MixerScreen.kt
@@ -207,10 +207,7 @@ fun MixerScreen(
             ) { Text(if (isProcessing) "Mixing..." else "Play & Save") }
         }
 
-        if (SettingsManager.isDebug(context)) {
-            val logs = DebugLogger.getLogs().joinToString("\n")
-            Text(logs, modifier = Modifier.fillMaxWidth())
-        }
+        // Debug logs moved to dedicated screen
     }
 }
 

--- a/app/src/main/java/com/example/kokoro82m/screens/MoreScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/MoreScreen.kt
@@ -9,10 +9,13 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.example.kokoro82m.utils.SettingsManager
 
 @Composable
 fun MoreScreen(onNavigate: (String) -> Unit) {
+    val context = LocalContext.current
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -36,6 +39,14 @@ fun MoreScreen(onNavigate: (String) -> Unit) {
             modifier = Modifier.fillMaxWidth()
         ) {
             Text("Models")
+        }
+        if (SettingsManager.isDebug(context)) {
+            Button(
+                onClick = { onNavigate("DebugLog") },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Debug Log")
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/utils/PhonemeConverter.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/PhonemeConverter.kt
@@ -23,16 +23,16 @@ class PhonemeConverter(context: Context) {
                         if (parts.size == 2) {
                             phonemeMap[parts[0]] = parts[1]
                         } else {
-                            println("Invalid line format: $line")
+                            DebugLogger.log("Invalid line format: $line")
                         }
                     }
                 }
-            println("Dictionary loaded successfully. Total entries: ${phonemeMap.size}")
+            DebugLogger.log("Dictionary loaded successfully. Total entries: ${phonemeMap.size}")
         } catch (e: IOException) {
-            println("Error loading dictionary: ${e.message}")
+            DebugLogger.log("Error loading dictionary: ${e.message}")
             e.printStackTrace()
         } catch (e: Resources.NotFoundException) {
-            println("Dictionary file not found: ${e.message}")
+            DebugLogger.log("Dictionary file not found: ${e.message}")
             e.printStackTrace()
         }
     }
@@ -64,7 +64,7 @@ class PhonemeConverter(context: Context) {
     fun phonemize(text: String, lang: String = "en-us", norm: Boolean = true): String {
 
         val normalizedText = if (norm) normalizeText(text) else text
-        println("normalText: $normalizedText")
+        DebugLogger.log("normalText: $normalizedText")
 
 
         val wordsAndPunctuation = normalizedText
@@ -74,7 +74,7 @@ class PhonemeConverter(context: Context) {
 
         val phonemes = StringBuilder()
         for ((index, word) in wordsAndPunctuation.withIndex()) {
-            println("word: $word")
+            DebugLogger.log("word: $word")
             val ipaPhonemes = if (word.matches(Regex("[^a-zA-Z']+"))) {
                 word
             } else {

--- a/app/src/main/java/com/example/kokoro82m/utils/Tokenizer.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/Tokenizer.kt
@@ -10,7 +10,7 @@ class Tokenizer {
 
 
         fun tokenize(phonemes: String): LongArray {
-            println("ALL PHONEMES: $phonemes")
+            DebugLogger.log("ALL PHONEMES: $phonemes")
             if (phonemes.length > MAX_PHONEME_LENGTH) {
                 throw IllegalArgumentException(
                     "Text is too long, must be less than $MAX_PHONEME_LENGTH phonemes"

--- a/app/src/main/java/com/example/kokoro82m/utils/WaveHelper.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/WaveHelper.kt
@@ -7,7 +7,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Environment
 import android.provider.MediaStore
-import android.util.Log
 import android.widget.Toast
 import java.io.OutputStream
 import java.nio.ByteBuffer
@@ -48,18 +47,18 @@ fun saveAudio(audioData: FloatArray, context: Context, name: String, sampleRate:
                 outputStream.write(header)
                 outputStream.write(byteBuffer.array())
             }
-            Log.d("Nabu", "Audio saved to: $uri")
+            DebugLogger.log("Audio saved to: $uri")
             (context as? Activity)?.runOnUiThread {
                 Toast.makeText(context, "Audio saved to Music directory", Toast.LENGTH_LONG).show()
             }
         } catch (e: Exception) {
-            Log.e("Nabu", "Error saving audio: ${e.message}")
+            DebugLogger.log("Error saving audio: ${e.message}")
             (context as? Activity)?.runOnUiThread {
                 Toast.makeText(context, "Error saving audio", Toast.LENGTH_LONG).show()
             }
         }
     } ?: run {
-        Log.e("Nabu", "Failed to create audio file")
+        DebugLogger.log("Failed to create audio file")
         (context as? Activity)?.runOnUiThread {
             Toast.makeText(context, "Failed to create audio file", Toast.LENGTH_LONG).show()
         }


### PR DESCRIPTION
## Summary
- remove inline debug log displays from Book and Mixer screens
- add dedicated DebugLogScreen accessible from More menu
- route all println and Log calls through DebugLogger

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689823825ab883319f57eba2901e5301