### PR TITLE
Handle long phoneme strings during audio generation

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/utils/BookPlayer.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/BookPlayer.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.collect
 import java.io.File
 import com.example.kokoro82m.utils.createKittenAudioFromStyleVector
 import com.example.kokoro82m.utils.KittenPhonemizer
@@ -60,24 +61,26 @@ fun playBook(
                     }
                     val line = lines[index]
                     val engine = SettingsManager.getTtsEngine(context)
-                    val (audio, _) = if (engine == TtsEngine.KITTEN) {
+                    if (engine == TtsEngine.KITTEN) {
                         val (_, tokens) = KittenPhonemizer.phonemize(line)
-                        createKittenAudioFromStyleVector(
+                        val (audio, _) = createKittenAudioFromStyleVector(
                             tokens = tokens,
                             voice = mixedVector,
                             speed = speed,
                             session = session,
                         )
+                        audioBuffer.send(Pair(audio, index))
                     } else {
                         val phonemes = phonemeConverter.phonemize(line)
-                        createAudioFromStyleVector(
+                        createAudioFlowFromStyleVector(
                             phonemes = phonemes,
                             voice = mixedVector,
                             speed = speed,
                             session = session,
-                        )
+                        ).collect { chunk ->
+                            audioBuffer.send(Pair(chunk, index))
+                        }
                     }
-                    audioBuffer.send(Pair(audio, index))
                 }
             } catch (e: Exception) {
                 DebugLogger.log("Audio generation failed: ${e.localizedMessage}")
@@ -88,16 +91,20 @@ fun playBook(
 
         // Consumer
         try {
+            var lastIndex = -1
             for ((audio, index) in audioBuffer) {
                 if (!isActive) {
                     completed = false
                     break
                 }
 
-                withContext(Dispatchers.Main) {
-                    onLineChanged(index)
+                if (index != lastIndex) {
+                    withContext(Dispatchers.Main) {
+                        onLineChanged(index)
+                    }
+                    DebugLogger.log("Playing line $index")
+                    lastIndex = index
                 }
-                DebugLogger.log("Playing line $index")
 
                 audioPlayer.prepare(audio, 0)
                 audioPlayer.playBlocking()

--- a/app/src/main/java/com/example/kokoro82m/utils/CreateAudio.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/CreateAudio.kt
@@ -5,6 +5,7 @@ import ai.onnxruntime.OrtEnvironment
 import ai.onnxruntime.OrtSession
 import android.content.Context
 import com.example.kokoro82m.utils.DebugLogger
+import com.example.kokoro82m.utils.PhonemeUtils
 
 fun createAudio(
     phonemes: String,
@@ -16,43 +17,47 @@ fun createAudio(
     val MAX_PHONEME_LENGTH = 400
     val SAMPLE_RATE = 22050
 
-    if (phonemes.length > MAX_PHONEME_LENGTH) {
-        DebugLogger.log("Phonemes too long, truncating to $MAX_PHONEME_LENGTH")
-    }
-    val truncatedPhonemes = phonemes.take(MAX_PHONEME_LENGTH)
-
-    val tokens = Tokenizer.tokenize(truncatedPhonemes)
-    if (tokens.size > MAX_PHONEME_LENGTH) {
-        throw IllegalArgumentException("Context length is $MAX_PHONEME_LENGTH, but leave room for the pad token 0 at the start & end")
+    val batches = PhonemeUtils.splitPhonemes(phonemes, MAX_PHONEME_LENGTH)
+    if (batches.size > 1) {
+        DebugLogger.log("Phonemes too long, splitting into ${batches.size} batches")
     }
 
     val styleLoader = StyleLoader(context)
     val styleArray = styleLoader.getStyleArray(voice)
+    val audioData = mutableListOf<Float>()
 
-    val paddedTokens = listOf(0L) + tokens.toList() + listOf(0L)
-    val tokenTensor = OnnxTensor.createTensor(
-        OrtEnvironment.getEnvironment(),
-        arrayOf(paddedTokens.toLongArray())
-    )
-    val styleTensor = OnnxTensor.createTensor(
-        OrtEnvironment.getEnvironment(),
-        styleArray
-    )
-    val speedTensor = OnnxTensor.createTensor(
-        OrtEnvironment.getEnvironment(),
-        floatArrayOf(speed)
-    )
+    for (batch in batches) {
+        val tokens = Tokenizer.tokenize(batch)
+        if (tokens.size > MAX_PHONEME_LENGTH) {
+            throw IllegalArgumentException("Context length is $MAX_PHONEME_LENGTH, but leave room for the pad token 0 at the start & end")
+        }
 
-    val inputs = mapOf(
-        "tokens" to tokenTensor,
-        "style" to styleTensor,
-        "speed" to speedTensor
-    )
-    val results = session.run(inputs)
-    val audioTensor = results[0].value as FloatArray
-    results.close()
+        val paddedTokens = listOf(0L) + tokens.toList() + listOf(0L)
+        val tokenTensor = OnnxTensor.createTensor(
+            OrtEnvironment.getEnvironment(),
+            arrayOf(paddedTokens.toLongArray())
+        )
+        val styleTensor = OnnxTensor.createTensor(
+            OrtEnvironment.getEnvironment(),
+            styleArray
+        )
+        val speedTensor = OnnxTensor.createTensor(
+            OrtEnvironment.getEnvironment(),
+            floatArrayOf(speed)
+        )
 
-    return Pair(audioTensor, SAMPLE_RATE)
+        val inputs = mapOf(
+            "tokens" to tokenTensor,
+            "style" to styleTensor,
+            "speed" to speedTensor
+        )
+        val results = session.run(inputs)
+        val audioTensor = results[0].value as FloatArray
+        results.close()
+        audioData.addAll(audioTensor.toList())
+    }
+
+    return Pair(audioData.toFloatArray(), SAMPLE_RATE)
 }
 
 fun createAudioFromStyleVector(
@@ -64,41 +69,45 @@ fun createAudioFromStyleVector(
     val MAX_PHONEME_LENGTH = 400
     val SAMPLE_RATE = 22050
 
-    if (phonemes.length > MAX_PHONEME_LENGTH) {
-        DebugLogger.log("Phonemes too long, truncating to $MAX_PHONEME_LENGTH")
-    }
-    val truncatedPhonemes = phonemes.take(MAX_PHONEME_LENGTH)
-
-    val tokens = Tokenizer.tokenize(truncatedPhonemes)
-    if (tokens.size > MAX_PHONEME_LENGTH) {
-        throw IllegalArgumentException("Context length is $MAX_PHONEME_LENGTH, but leave room for the pad token 0 at the start & end")
+    val batches = PhonemeUtils.splitPhonemes(phonemes, MAX_PHONEME_LENGTH)
+    if (batches.size > 1) {
+        DebugLogger.log("Phonemes too long, splitting into ${batches.size} batches")
     }
 
-    val paddedTokens = listOf(0L) + tokens.toList() + listOf(0L)
-    val tokenTensor = OnnxTensor.createTensor(
-        OrtEnvironment.getEnvironment(),
-        arrayOf(paddedTokens.toLongArray())
-    )
-    val styleTensor = OnnxTensor.createTensor(
-        OrtEnvironment.getEnvironment(),
-        voice
-    )
+    val audioData = mutableListOf<Float>()
+    for (batch in batches) {
+        val tokens = Tokenizer.tokenize(batch)
+        if (tokens.size > MAX_PHONEME_LENGTH) {
+            throw IllegalArgumentException("Context length is $MAX_PHONEME_LENGTH, but leave room for the pad token 0 at the start & end")
+        }
 
-    val speedTensor = OnnxTensor.createTensor(
-        OrtEnvironment.getEnvironment(),
-        floatArrayOf(speed)
-    )
+        val paddedTokens = listOf(0L) + tokens.toList() + listOf(0L)
+        val tokenTensor = OnnxTensor.createTensor(
+            OrtEnvironment.getEnvironment(),
+            arrayOf(paddedTokens.toLongArray())
+        )
+        val styleTensor = OnnxTensor.createTensor(
+            OrtEnvironment.getEnvironment(),
+            voice
+        )
 
-    val inputs = mapOf(
-        "tokens" to tokenTensor,
-        "style" to styleTensor,
-        "speed" to speedTensor
-    )
-    val results = session.run(inputs)
-    val audioTensor = results[0].value as FloatArray
-    results.close()
+        val speedTensor = OnnxTensor.createTensor(
+            OrtEnvironment.getEnvironment(),
+            floatArrayOf(speed)
+        )
 
-    return Pair(audioTensor, SAMPLE_RATE)
+        val inputs = mapOf(
+            "tokens" to tokenTensor,
+            "style" to styleTensor,
+            "speed" to speedTensor
+        )
+        val results = session.run(inputs)
+        val audioTensor = results[0].value as FloatArray
+        results.close()
+        audioData.addAll(audioTensor.toList())
+    }
+
+    return Pair(audioData.toFloatArray(), SAMPLE_RATE)
 }
 
 fun createKittenAudioFromStyleVector(

--- a/app/src/main/java/com/example/kokoro82m/utils/CreateAudio.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/CreateAudio.kt
@@ -4,6 +4,8 @@ import ai.onnxruntime.OnnxTensor
 import ai.onnxruntime.OrtEnvironment
 import ai.onnxruntime.OrtSession
 import android.content.Context
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import com.example.kokoro82m.utils.DebugLogger
 import com.example.kokoro82m.utils.PhonemeUtils
 
@@ -108,6 +110,50 @@ fun createAudioFromStyleVector(
     }
 
     return Pair(audioData.toFloatArray(), SAMPLE_RATE)
+}
+
+fun createAudioFlowFromStyleVector(
+    phonemes: String,
+    voice: Array<FloatArray>,
+    speed: Float,
+    session: OrtSession,
+): Flow<FloatArray> = flow {
+    val MAX_PHONEME_LENGTH = 400
+    val batches = PhonemeUtils.splitPhonemes(phonemes, MAX_PHONEME_LENGTH)
+    if (batches.size > 1) {
+        DebugLogger.log("Phonemes too long, streaming ${batches.size} batches")
+    }
+
+    for (batch in batches) {
+        val tokens = Tokenizer.tokenize(batch)
+        if (tokens.size > MAX_PHONEME_LENGTH) {
+            throw IllegalArgumentException("Context length is $MAX_PHONEME_LENGTH, but leave room for the pad token 0 at the start & end")
+        }
+
+        val paddedTokens = listOf(0L) + tokens.toList() + listOf(0L)
+        val tokenTensor = OnnxTensor.createTensor(
+            OrtEnvironment.getEnvironment(),
+            arrayOf(paddedTokens.toLongArray())
+        )
+        val styleTensor = OnnxTensor.createTensor(
+            OrtEnvironment.getEnvironment(),
+            voice
+        )
+        val speedTensor = OnnxTensor.createTensor(
+            OrtEnvironment.getEnvironment(),
+            floatArrayOf(speed)
+        )
+
+        val inputs = mapOf(
+            "tokens" to tokenTensor,
+            "style" to styleTensor,
+            "speed" to speedTensor
+        )
+        val results = session.run(inputs)
+        val audioTensor = results[0].value as FloatArray
+        results.close()
+        emit(audioTensor)
+    }
 }
 
 fun createKittenAudioFromStyleVector(

--- a/app/src/main/java/com/example/kokoro82m/utils/PhonemeUtils.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/PhonemeUtils.kt
@@ -1,0 +1,43 @@
+package com.example.kokoro82m.utils
+
+object PhonemeUtils {
+    private val PUNCTUATION_REGEX = Regex("([.,!?;])")
+
+    fun splitPhonemes(phonemes: String, maxLength: Int): List<String> {
+        val words = mutableListOf<String>()
+        var lastIndex = 0
+        for (match in PUNCTUATION_REGEX.findAll(phonemes)) {
+            if (lastIndex < match.range.first) {
+                words.add(phonemes.substring(lastIndex, match.range.first))
+            }
+            words.add(match.value)
+            lastIndex = match.range.last + 1
+        }
+        if (lastIndex < phonemes.length) {
+            words.add(phonemes.substring(lastIndex))
+        }
+
+        val batches = mutableListOf<String>()
+        var currentBatch = StringBuilder()
+        for (part in words) {
+            val trimmed = part.trim()
+            if (trimmed.isEmpty()) continue
+            if (currentBatch.length + trimmed.length + 1 >= maxLength) {
+                batches.add(currentBatch.toString().trim())
+                currentBatch = StringBuilder(trimmed)
+            } else {
+                if (trimmed in listOf(".", ",", "!", "?", ";")) {
+                    currentBatch.append(trimmed)
+                } else {
+                    if (currentBatch.isNotEmpty()) currentBatch.append(' ')
+                    currentBatch.append(trimmed)
+                }
+            }
+        }
+        if (currentBatch.isNotEmpty()) {
+            batches.add(currentBatch.toString().trim())
+        }
+        return batches
+    }
+}
+


### PR DESCRIPTION
## Summary
- Split phoneme text by punctuation to respect model limits
- Generate audio for each phoneme batch and concatenate results

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_689823c691188331b7771f3ad67b41c2