### PR TITLE
Avoid mispronouncing short lowercase words as acronyms

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.inline)
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+    testImplementation("androidx.test:core:1.5.0")
+    testImplementation("org.robolectric:robolectric:4.11.1")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/example/kokoro82m/utils/PhonemeConverter.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/PhonemeConverter.kt
@@ -38,17 +38,22 @@ class PhonemeConverter(context: Context) {
     }
 
     private fun convertToPhonemes(word: String): String {
-
         if (word.matches(Regex("[^a-zA-Z']+"))) {
             return word
         }
 
+        val cleanUpper = word.replace(Regex("[^a-zA-Z']"), "").uppercase()
+        val phonemesFromDict = phonemeMap[cleanUpper]
 
-        val cleanWord = word.replace(Regex("[^a-zA-Z']"), "").uppercase()
-        val arpabetWithoutStress = cleanWord.replace(Regex("[0-9]"), "ˈ")
-        val phonemes = phonemeMap[arpabetWithoutStress] ?: return fallbackTranscribe(word)
+        val wasAllLowercase = word.all { it.isLowerCase() }
+        if (phonemesFromDict != null && wasAllLowercase && word.length <= 3) {
+            val stressCount = phonemesFromDict.count { it == 'ˈ' || it == 'ˌ' }
+            if (stressCount > 1) {
+                return fallbackTranscribe(word)
+            }
+        }
 
-
+        val phonemes = phonemesFromDict ?: return fallbackTranscribe(word)
 
         return phonemes.split(",").first().trim()
     }

--- a/app/src/test/java/com/example/kokoro82m/utils/PhonemeAcronymTest.kt
+++ b/app/src/test/java/com/example/kokoro82m/utils/PhonemeAcronymTest.kt
@@ -1,0 +1,26 @@
+package com.example.kokoro82m.utils
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.robolectric.RobolectricTestRunner
+import org.junit.runner.RunWith
+
+@RunWith(RobolectricTestRunner::class)
+class PhonemeAcronymTest {
+    private lateinit var converter: PhonemeConverter
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        converter = PhonemeConverter(context)
+    }
+
+    @Test
+    fun `it is not treated as initialism`() {
+        val phonemes = converter.phonemize("it")
+        assertEquals("ɪt", phonemes)
+    }
+}
+


### PR DESCRIPTION
## Summary
- Treat short lowercase tokens with multiple stress markers as likely acronyms and fall back to g2p transcription
- Add Robolectric unit test ensuring "it" is converted to \u026At instead of spelled out
- Enable Robolectric and AndroidX test core dependencies for unit tests

## Testing
- `gradle test` *(fails: Execution failed for task ':app:testDebugUnitTest'. See the report at: file:///workspace/Kokoro-82M-Android/app/build/reports/tests/testDebugUnitTest/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_689947a0acf083319cd597a3d80b4bc1