### PR TITLE
Refresh voice list when changing TTS engine

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -426,11 +426,12 @@ fun BasicScreen(
     onGenerateAudio: (String, String, Float, Boolean, () -> Unit) -> Unit,
 ) {
     val context = LocalContext.current
-    val styleLoader = remember { StyleLoader(context) }
+    var engine by remember { mutableStateOf(SettingsManager.getTtsEngine(context)) }
+    val styleLoader = remember(engine) { StyleLoader(context) }
     val names = styleLoader.names.sorted()
 
     var text by remember { mutableStateOf("This is her warm heart, her warmest kokoro, unwavering love and comfort.") }
-    var style by remember {
+    var style by remember(engine) {
         mutableStateOf(
             SettingsManager.getStyle(context).takeIf { it in names }
                 ?: names.firstOrNull().orEmpty()
@@ -439,12 +440,12 @@ fun BasicScreen(
     var speed by remember { mutableFloatStateOf(SettingsManager.getSpeed(context)) }
     var isProcessing by remember { mutableStateOf(false) }
     var shouldSaveFile by remember { mutableStateOf(false) }
-    var engine by remember { mutableStateOf(SettingsManager.getTtsEngine(context)) }
 
     LaunchedEffect(engine) {
         withContext(Dispatchers.IO) {
             OnnxRuntimeManager.initialize(context.applicationContext)
         }
+        SettingsManager.setStyle(context, style)
     }
 
     var expanded by remember { mutableStateOf(false) }


### PR DESCRIPTION
## Summary
- Recreate StyleLoader and reset voice selection when the TTS engine changes on the Basic screen

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899904d0c588331b6348b1ecf4a14da