### PR TITLE
Add notification controls for play, pause, and stop

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/utils/PlaybackNotification.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/PlaybackNotification.kt
@@ -13,16 +13,15 @@ object PlaybackNotification {
     private const val CHANNEL_ID = "book_playback_channel"
     private const val NOTIFICATION_ID = 1001
 
-    fun show(context: Context, playing: Boolean) {
+    fun show(context: Context, state: PlayerState) {
         createChannel(context)
-        val notification = buildNotification(context, playing)
+        val notification = buildNotification(context, state)
         NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification)
     }
 
     fun update(context: Context, state: PlayerState) {
         when (state) {
-            PlayerState.PLAYING -> show(context, true)
-            PlayerState.PAUSED -> show(context, false)
+            PlayerState.PLAYING, PlayerState.PAUSED -> show(context, state)
             PlayerState.IDLE -> cancel(context)
         }
     }
@@ -31,24 +30,70 @@ object PlaybackNotification {
         NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID)
     }
 
-    private fun buildNotification(context: Context, playing: Boolean) =
-        NotificationCompat.Builder(context, CHANNEL_ID)
+    private fun buildNotification(context: Context, state: PlayerState): android.app.Notification {
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_media_play)
             .setContentTitle("Book Playback")
-            .setContentText(if (playing) "Playing" else "Paused")
-            .setOngoing(playing)
-            .addAction(
-                if (playing) android.R.drawable.ic_media_pause else android.R.drawable.ic_media_play,
-                if (playing) "Pause" else "Play",
-                PendingIntent.getBroadcast(
-                    context,
-                    0,
-                    Intent(PlaybackReceiver.ACTION_TOGGLE),
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                )
-            )
             .setOnlyAlertOnce(true)
-            .build()
+
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+
+        when (state) {
+            PlayerState.PLAYING -> {
+                builder.setContentText("Playing")
+                    .setOngoing(true)
+                    .addAction(
+                        android.R.drawable.ic_media_pause,
+                        "Pause",
+                        PendingIntent.getBroadcast(
+                            context,
+                            0,
+                            Intent(PlaybackReceiver.ACTION_PAUSE),
+                            flags
+                        )
+                    )
+                    .addAction(
+                        android.R.drawable.ic_menu_close_clear_cancel,
+                        "Stop",
+                        PendingIntent.getBroadcast(
+                            context,
+                            1,
+                            Intent(PlaybackReceiver.ACTION_STOP),
+                            flags
+                        )
+                    )
+            }
+            PlayerState.PAUSED -> {
+                builder.setContentText("Paused")
+                    .setOngoing(false)
+                    .addAction(
+                        android.R.drawable.ic_media_play,
+                        "Play",
+                        PendingIntent.getBroadcast(
+                            context,
+                            0,
+                            Intent(PlaybackReceiver.ACTION_PLAY),
+                            flags
+                        )
+                    )
+                    .addAction(
+                        android.R.drawable.ic_menu_close_clear_cancel,
+                        "Stop",
+                        PendingIntent.getBroadcast(
+                            context,
+                            1,
+                            Intent(PlaybackReceiver.ACTION_STOP),
+                            flags
+                        )
+                    )
+            }
+            else -> {
+                builder.setContentText("Stopped").setOngoing(false)
+            }
+        }
+
+        return builder.build()
+    }
 
     private fun createChannel(context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/app/src/main/java/com/example/kokoro82m/utils/PlaybackReceiver.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/PlaybackReceiver.kt
@@ -6,19 +6,26 @@ import android.content.Intent
 
 class PlaybackReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action == ACTION_TOGGLE) {
-            val player = AudioPlayerManager.player ?: return
-            if (player.getState() == PlayerState.PLAYING) {
-                player.pause()
-                PlaybackNotification.update(context, PlayerState.PAUSED)
-            } else {
+        val player = AudioPlayerManager.player ?: return
+        when (intent.action) {
+            ACTION_PLAY -> {
                 player.play()
                 PlaybackNotification.update(context, PlayerState.PLAYING)
+            }
+            ACTION_PAUSE -> {
+                player.pause()
+                PlaybackNotification.update(context, PlayerState.PAUSED)
+            }
+            ACTION_STOP -> {
+                player.stop()
+                PlaybackNotification.update(context, PlayerState.IDLE)
             }
         }
     }
 
     companion object {
-        const val ACTION_TOGGLE = "com.example.kokoro82m.PLAYBACK_TOGGLE"
+        const val ACTION_PLAY = "com.example.kokoro82m.PLAYBACK_PLAY"
+        const val ACTION_PAUSE = "com.example.kokoro82m.PLAYBACK_PAUSE"
+        const val ACTION_STOP = "com.example.kokoro82m.PLAYBACK_STOP"
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
@@ -95,7 +95,7 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
         appContext = context.applicationContext
         initializeAudioPlayer(engine)
         AudioPlayerManager.player = audioPlayer
-        PlaybackNotification.show(appContext!!, true)
+        PlaybackNotification.show(appContext!!, PlayerState.PLAYING)
         playJob = playBook(
             scope = viewModelScope,
             session = session,


### PR DESCRIPTION
## Summary
- Add distinct play, pause, and stop actions to playback notification
- Handle new actions in `PlaybackReceiver`
- Update `BookViewModel` to use new notification API

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a2865380083319c94aab2f86f2db6