### PR TITLE
feat: add interactive credits constellation screen

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -8,6 +8,7 @@ import com.example.kokoro82m.screens.SettingsScreen
 import com.example.kokoro82m.screens.MixerScreen
 import com.example.kokoro82m.screens.MoreScreen
 import com.example.kokoro82m.screens.ModelsScreen
+import com.example.kokoro82m.screens.CreditsConstellationScreen
 import com.example.kokoro.galleryport.PerfHud
 import ai.onnxruntime.OrtSession
 import android.app.Application
@@ -263,6 +264,7 @@ private fun screenFromString(name: String?): Screen = when (name) {
     "Settings" -> Screen.Settings
     "About" -> Screen.About
     "Models" -> Screen.Models
+    "Credits" -> Screen.Credits
     else -> Screen.Basic
 }
 
@@ -277,6 +279,7 @@ sealed class Screen(val title: String) {
     object Settings : Screen("Settings")
     object About : Screen("About this app")
     object Models : Screen("Models")
+    object Credits : Screen("Credits")
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -384,6 +387,7 @@ fun MainScreen(
                         "Creations" -> Screen.Creations
                         "Settings" -> Screen.Settings
                         "Models" -> Screen.Models
+                        "Credits" -> Screen.Credits
                         else -> currentScreen
                     }
                 }
@@ -391,6 +395,7 @@ fun MainScreen(
                 Screen.Settings -> SettingsScreen()
                 Screen.About -> AboutScreen()
                 Screen.Models -> ModelsScreen(userPreferencesRepository)
+                Screen.Credits -> CreditsConstellationScreen()
             }
         }
     }

--- a/app/src/main/java/com/example/kokoro82m/screens/CreditsConstellationScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/CreditsConstellationScreen.kt
@@ -1,0 +1,155 @@
+package com.example.kokoro82m.screens
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+// Represents a group of credits that can contain entries and nested child clusters
+data class CreditCluster(
+    val name: String,
+    val entries: List<String> = emptyList(),
+    val children: List<CreditCluster> = emptyList()
+)
+
+@Composable
+fun CreditsConstellationScreen() {
+    // Original credits from upstream author preserved exactly
+    val originalCredits = remember {
+        CreditCluster(
+            name = "puff-dayo",
+            children = listOf(
+                CreditCluster(
+                    name = "Acknowledgements",
+                    entries = listOf(
+                        "Kokoro: a frontier TTS model (Apache 2.0)",
+                        "Kokoro-ONNX: converted kokoro (MIT)",
+                        "CMU dict: a pronunciation dictionary",
+                        "IPA Transcribers: language transliterators (GPL-3.0)",
+                        "Android NNAPI: a machine learning API"
+                    )
+                )
+            )
+        )
+    }
+
+    // Our own constellation for additional acknowledgements
+    val ourCredits = remember {
+        CreditCluster(
+            name = "Our Credit Wall",
+            entries = listOf(
+                "AGI - project guidance"
+            )
+        )
+    }
+
+    val clusters = listOf(originalCredits, ourCredits)
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        items(clusters) { cluster ->
+            StarCluster(cluster = cluster)
+        }
+    }
+}
+
+@Composable
+private fun StarCluster(cluster: CreditCluster, level: Int = 0, modifier: Modifier = Modifier) {
+    var expanded by remember { mutableStateOf(false) }
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = Icons.Filled.Star,
+                contentDescription = cluster.name,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .size(if (level == 0) 56.dp else 32.dp)
+                    .clickable { expanded = !expanded }
+            )
+            Text(
+                text = cluster.name,
+                style = MaterialTheme.typography.labelMedium,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(top = if (level == 0) 64.dp else 40.dp)
+            )
+        }
+        AnimatedVisibility(expanded) {
+            ConstellationEntries(cluster = cluster, level = level)
+        }
+    }
+}
+
+@Composable
+private fun ConstellationEntries(cluster: CreditCluster, level: Int) {
+    val radius = if (level == 0) 100.dp else 60.dp
+    Box(
+        modifier = Modifier.size(radius * 2),
+        contentAlignment = Alignment.Center
+    ) {
+        val density = LocalDensity.current
+        val total = cluster.entries.size + cluster.children.size
+        cluster.entries.forEachIndexed { index, entry ->
+            val angle = 2 * PI * index / total
+            Text(
+                text = entry,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.offset {
+                    val r = with(density) { radius.toPx() }
+                    IntOffset(
+                        x = (cos(angle) * r).roundToInt(),
+                        y = (sin(angle) * r).roundToInt()
+                    )
+                }
+            )
+        }
+        cluster.children.forEachIndexed { index, child ->
+            val angle = 2 * PI * (cluster.entries.size + index) / total
+            StarCluster(
+                cluster = child,
+                level = level + 1,
+                modifier = Modifier.offset {
+                    val r = with(density) { radius.toPx() }
+                    IntOffset(
+                        x = (cos(angle) * r).roundToInt(),
+                        y = (sin(angle) * r).roundToInt()
+                    )
+                }
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/kokoro82m/screens/MoreScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/MoreScreen.kt
@@ -37,5 +37,11 @@ fun MoreScreen(onNavigate: (String) -> Unit) {
         ) {
             Text("Models")
         }
+        Button(
+            onClick = { onNavigate("Credits") },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Credits")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- introduce `CreditsConstellationScreen` for displaying credit groups as tappable star clusters
- wire credits screen into navigation and expose from More menu

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a69eebc6483319e2bc0c8a8006e67