### PR TITLE
feat: allow external chat models

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/ChatActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/ChatActivity.kt
@@ -58,11 +58,11 @@ class ChatActivity : ComponentActivity() {
     }
 
     private fun startChat(model: Model) {
-        val modelFile = File(filesDir, "models/${model.id}.task")
+        val modelPath = model.localPath ?: File(filesDir, "models/${model.id}.task").absolutePath
 
         val llmInference = LlmInference(
             context = applicationContext,
-            modelPath = modelFile.absolutePath
+            modelPath = modelPath
         )
         llmInference.initialize()
 

--- a/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
@@ -63,8 +63,8 @@ class ChatTtsActivity : ComponentActivity() {
     }
 
     private fun startChat(model: Model, session: ai.onnxruntime.OrtSession) {
-        val modelFile = File(filesDir, "models/${model.id}.task")
-        val llmInference = LlmInference(applicationContext, modelFile.absolutePath)
+        val modelPath = model.localPath ?: File(filesDir, "models/${model.id}.task").absolutePath
+        val llmInference = LlmInference(applicationContext, modelPath)
 
         val viewModel: ChatTtsViewModel by viewModels {
             object : ViewModelProvider.Factory {

--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -424,8 +424,8 @@ fun BasicScreen(
 
     LaunchedEffect(selectedModel) {
         selectedModel?.let {
-            val modelFile = java.io.File(context.filesDir, "models/${it.id}.task")
-            viewModel.reinitializeSession(modelFile.absolutePath)
+            val modelPath = it.localPath ?: java.io.File(context.filesDir, "models/${it.id}.task").absolutePath
+            viewModel.reinitializeSession(modelPath)
         }
     }
 

--- a/app/src/main/java/com/example/kokoro82m/data/Model.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/Model.kt
@@ -7,6 +7,8 @@ data class Model(
     val repo: String,
     val downloadUrl: String,
     val gated: Boolean,
+    /** Optional absolute path if the model lives outside app storage */
+    var localPath: String? = null,
     var isDownloaded: Boolean = false,
     var hasPartial: Boolean = false,
 )

--- a/app/src/main/java/com/example/kokoro82m/data/ModelManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/ModelManager.kt
@@ -15,6 +15,7 @@ class ModelManager(private val context: Context) {
         val jsonString = context.resources.openRawResource(R.raw.model_allowlist).bufferedReader().use { it.readText() }
         val json = JSONObject(jsonString)
         val keys = json.keys()
+        val externalDirPath = System.getenv("KOKORO_MODEL_DIR")
         while (keys.hasNext()) {
             val key = keys.next()
             val modelJson = json.getJSONObject(key)
@@ -26,11 +27,20 @@ class ModelManager(private val context: Context) {
                 downloadUrl = modelJson.getString("downloadUrl"),
                 gated = modelJson.optBoolean("gated", false)
             )
-            val modelDir = java.io.File(context.filesDir, "models")
-            val modelFile = java.io.File(modelDir, "${model.id}.task")
-            val partialFile = java.io.File(modelDir, "${model.id}.task.part")
-            model.isDownloaded = modelFile.exists()
-            model.hasPartial = !model.isDownloaded && partialFile.exists()
+
+            val internalDir = java.io.File(context.filesDir, "models")
+            val internalFile = java.io.File(internalDir, "${model.id}.task")
+            val externalFile = externalDirPath?.let { java.io.File(it, "${model.id}.task") }
+            val partialFile = java.io.File(internalDir, "${model.id}.task.part")
+
+            model.localPath = when {
+                internalFile.exists() -> internalFile.absolutePath
+                externalFile?.exists() == true -> externalFile.absolutePath
+                else -> null
+            }
+
+            model.isDownloaded = model.localPath != null
+            model.hasPartial = model.localPath == null && partialFile.exists()
             modelList.add(model)
         }
         return modelList


### PR DESCRIPTION
## Summary
- support `KOKORO_MODEL_DIR` so chat models can live outside app storage
- load chat & chat+tts models using their resolved path
- reuse resolved path when reinitializing TTS session

## Testing
- `gradle -q app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ac7a36e908331833f60808f6c0e8d