### PR TITLE
feat: support line-based book reading

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/utils/DocumentReader.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/DocumentReader.kt
@@ -10,10 +10,21 @@ import kotlinx.coroutines.flow.flowOn
 object DocumentReader {
     data class Result(val chunks: Flow<String>, val title: String)
 
-    fun asFlow(ctx: Context, uri: Uri, chunkSize: Int = 1600): Result {
-        val (seq, meta) = TextExtractor.extract(ctx, uri, chunkSize)
+    fun asFlow(
+        ctx: Context,
+        uri: Uri,
+        chunkSize: Int = 1600,
+        byLine: Boolean = false
+    ): Result {
+        val (seq, meta) = TextExtractor.extract(ctx, uri, if (byLine) Int.MAX_VALUE else chunkSize)
         val fl = flow {
-            for (c in seq) emit(c)
+            for (block in seq) {
+                if (byLine) {
+                    block.lineSequence().forEach { emit(it) }
+                } else {
+                    emit(block)
+                }
+            }
         }.flowOn(Dispatchers.IO)
         return Result(chunks = fl, title = meta.displayName)
     }

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
@@ -64,9 +64,9 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
     fun loadBook(context: Context, uri: Uri) {
         _bookUri.value = uri
         viewModelScope.launch(Dispatchers.IO) {
-            val text = DocumentReader.asFlow(context, uri).chunks.toList().joinToString("\n")
+            val lines = DocumentReader.asFlow(context, uri, byLine = true).chunks.toList()
             withContext(Dispatchers.Main) {
-                _lines.value = text.lines()
+                _lines.value = lines
             }
         }
     }
@@ -125,7 +125,7 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
     }
 
     fun openDocument(uri: Uri) {
-        val result = DocumentReader.asFlow(app, uri, chunkSize = 1600)
+        val result = DocumentReader.asFlow(app, uri, byLine = true)
         ChunkFeeder.start(viewModelScope, result.chunks)
     }
 


### PR DESCRIPTION
## Summary
- allow DocumentReader to emit lines for finer-grained text access
- load/open books line-by-line to enable precise bookmarking and clipping

## Testing
- `curl -L -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-8.10.2-bin.zip && unzip -q /tmp/gradle.zip -d /tmp/ && /tmp/gradle-8.10.2/bin/gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae5a58a488331aa78f2a50a97c737