### PR TITLE
feat: support line-based book reading

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/utils/DocumentReader.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/DocumentReader.kt
@@ -14,13 +14,18 @@ object DocumentReader {
         ctx: Context,
         uri: Uri,
         chunkSize: Int = 1600,
-        byLine: Boolean = false
+        byLine: Boolean = false,
+        lineLength: Int = 120
     ): Result {
         val (seq, meta) = TextExtractor.extract(ctx, uri, if (byLine) Int.MAX_VALUE else chunkSize)
         val fl = flow {
             for (block in seq) {
                 if (byLine) {
-                    block.lineSequence().forEach { emit(it) }
+                    block.lineSequence()
+                        .flatMap { it.chunked(lineLength).asSequence() }
+                        .map { it.trim() }
+                        .filter { it.isNotEmpty() }
+                        .forEach { emit(it) }
                 } else {
                     emit(block)
                 }

--- a/app/src/main/java/com/example/kokoro82m/utils/DocumentReader.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/DocumentReader.kt
@@ -2,6 +2,7 @@ package com.example.kokoro82m.utils
 
 import android.content.Context
 import android.net.Uri
+import java.text.BreakIterator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -14,18 +15,13 @@ object DocumentReader {
         ctx: Context,
         uri: Uri,
         chunkSize: Int = 1600,
-        byLine: Boolean = false,
-        lineLength: Int = 120
+        bySentence: Boolean = false // Renamed from byLine to bySentence for clarity
     ): Result {
-        val (seq, meta) = TextExtractor.extract(ctx, uri, if (byLine) Int.MAX_VALUE else chunkSize)
+        val (seq, meta) = TextExtractor.extract(ctx, uri, if (bySentence) Int.MAX_VALUE else chunkSize)
         val fl = flow {
             for (block in seq) {
-                if (byLine) {
-                    block.lineSequence()
-                        .flatMap { it.chunked(lineLength).asSequence() }
-                        .map { it.trim() }
-                        .filter { it.isNotEmpty() }
-                        .forEach { emit(it) }
+                if (bySentence) {
+                    block.toSentences().forEach { emit(it) }
                 } else {
                     emit(block)
                 }
@@ -33,5 +29,21 @@ object DocumentReader {
         }.flowOn(Dispatchers.IO)
         return Result(chunks = fl, title = meta.displayName)
     }
-}
 
+    private fun String.toSentences(): List<String> {
+        val boundary = BreakIterator.getSentenceInstance()
+        boundary.setText(this)
+        val sentences = mutableListOf<String>()
+        var start = boundary.first()
+        var end = boundary.next()
+        while (end != BreakIterator.DONE) {
+            val sentence = substring(start, end).trim()
+            if (sentence.isNotEmpty()) {
+                sentences.add(sentence)
+            }
+            start = end
+            end = boundary.next()
+        }
+        return sentences
+    }
+}

--- a/app/src/main/java/com/example/kokoro82m/utils/DocumentReader.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/DocumentReader.kt
@@ -2,7 +2,6 @@ package com.example.kokoro82m.utils
 
 import android.content.Context
 import android.net.Uri
-import java.text.BreakIterator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -15,35 +14,27 @@ object DocumentReader {
         ctx: Context,
         uri: Uri,
         chunkSize: Int = 1600,
-        bySentence: Boolean = false // Renamed from byLine to bySentence for clarity
+        byLine: Boolean = false,
+        lineLength: Int = 120
     ): Result {
-        val (seq, meta) = TextExtractor.extract(ctx, uri, if (bySentence) Int.MAX_VALUE else chunkSize)
+        val (seq, meta) = TextExtractor.extract(ctx, uri, if (byLine) Int.MAX_VALUE else chunkSize)
         val fl = flow {
             for (block in seq) {
-                if (bySentence) {
-                    block.toSentences().forEach { emit(it) }
+                if (byLine) {
+                    // Split incoming text on punctuation or whitespace to create stable
+                    // line-based chunks suitable for bookmarking, while preserving
+                    // document loading behaviour across formats like EPUB.
+                    block.split(Regex("(?<=[.!?])\\s+|\\n+"))
+                        .asSequence()
+                        .flatMap { it.chunked(lineLength).asSequence() }
+                        .map { it.trim() }
+                        .filter { it.isNotEmpty() }
+                        .forEach { emit(it) }
                 } else {
                     emit(block)
                 }
             }
         }.flowOn(Dispatchers.IO)
         return Result(chunks = fl, title = meta.displayName)
-    }
-
-    private fun String.toSentences(): List<String> {
-        val boundary = BreakIterator.getSentenceInstance()
-        boundary.setText(this)
-        val sentences = mutableListOf<String>()
-        var start = boundary.first()
-        var end = boundary.next()
-        while (end != BreakIterator.DONE) {
-            val sentence = substring(start, end).trim()
-            if (sentence.isNotEmpty()) {
-                sentences.add(sentence)
-            }
-            start = end
-            end = boundary.next()
-        }
-        return sentences
     }
 }

--- a/app/src/main/java/com/example/kokoro82m/utils/DocumentReader.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/DocumentReader.kt
@@ -10,10 +10,21 @@ import kotlinx.coroutines.flow.flowOn
 object DocumentReader {
     data class Result(val chunks: Flow<String>, val title: String)
 
-    fun asFlow(ctx: Context, uri: Uri, chunkSize: Int = 1600): Result {
-        val (seq, meta) = TextExtractor.extract(ctx, uri, chunkSize)
+    fun asFlow(
+        ctx: Context,
+        uri: Uri,
+        chunkSize: Int = 1600,
+        byLine: Boolean = false
+    ): Result {
+        val (seq, meta) = TextExtractor.extract(ctx, uri, if (byLine) Int.MAX_VALUE else chunkSize)
         val fl = flow {
-            for (c in seq) emit(c)
+            for (block in seq) {
+                if (byLine) {
+                    block.lineSequence().forEach { emit(it) }
+                } else {
+                    emit(block)
+                }
+            }
         }.flowOn(Dispatchers.IO)
         return Result(chunks = fl, title = meta.displayName)
     }

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
@@ -64,7 +64,10 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
     fun loadBook(context: Context, uri: Uri) {
         _bookUri.value = uri
         viewModelScope.launch(Dispatchers.IO) {
-            val lines = DocumentReader.asFlow(context, uri, byLine = true).chunks.toList()
+            val lines = DocumentReader
+                .asFlow(context, uri, byLine = true, lineLength = 120)
+                .chunks
+                .toList()
             withContext(Dispatchers.Main) {
                 _lines.value = lines
             }
@@ -125,7 +128,7 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
     }
 
     fun openDocument(uri: Uri) {
-        val result = DocumentReader.asFlow(app, uri, byLine = true)
+        val result = DocumentReader.asFlow(app, uri, byLine = true, lineLength = 120)
         ChunkFeeder.start(viewModelScope, result.chunks)
     }
 

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/BookViewModel.kt
@@ -64,9 +64,9 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
     fun loadBook(context: Context, uri: Uri) {
         _bookUri.value = uri
         viewModelScope.launch(Dispatchers.IO) {
-            val text = DocumentReader.asFlow(context, uri).chunks.toList().joinToString("\n")
+            val lines = DocumentReader.asFlow(context, uri, byLine = true).chunks.toList()
             withContext(Dispatchers.Main) {
-                _lines.value = text.lines()
+                _lines.value = lines
             }
         }
     }
@@ -125,7 +125,7 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
     }
 
     fun openDocument(uri: Uri) {
-        val result = DocumentReader.asFlow(app, uri, chunkSize = 1600)
+        val result = DocumentReader.asFlow(app, uri, byLine = true)
         ChunkFeeder.start(viewModelScope, result.chunks)
     }
 


### PR DESCRIPTION
## Summary
- allow DocumentReader to emit lines for finer-grained text access
- load/open books line-by-line to enable precise bookmarking and clipping

## Testing
- `curl -L -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-8.10.2-bin.zip && unzip -q /tmp/gradle.zip -d /tmp/ && /tmp/gradle-8.10.2/bin/gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae5a58a488331aa78f2a50a97c737