### PR TITLE
Use Nabu logo for splash screen

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -7,7 +7,7 @@
 
     <style name="AppTheme.Splash" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/nabu_launcher_background</item>
-        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_nabu_foreground</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_nabu_logo</item>
         <item name="postSplashScreenTheme">@style/AppTheme</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- show the Nabu logo on the splash screen

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689beac7d4588331a6c415c57dedff9e