### PR TITLE
feat: add local LLM import

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
     implementation("com.github.medavox:IPA-Transcribers:v0.2")
     implementation("com.tom-roush:pdfbox-android:2.0.27.0")
     implementation("org.jsoup:jsoup:1.17.2")
+    implementation("androidx.documentfile:documentfile:1.0.1")
 
     val lifecycle_version = "2.8.7"
     val arch_version = "2.2.0"

--- a/app/src/main/java/com/example/kokoro82m/data/ModelManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/ModelManager.kt
@@ -1,18 +1,37 @@
 package com.example.kokoro82m.data
 
 import android.content.Context
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.example.kokoro82m.R
 import org.json.JSONObject
+import java.io.File
 
+/**
+ * Manages available LLM models for the application.
+ *
+ * Models from the allowlist are loaded on start and any `.task` files
+ * already present in the models directory are treated as user supplied
+ * models. Additional models can be added at runtime by calling
+ * [addLocalModel].
+ */
 class ModelManager(private val context: Context) {
 
-    val models: List<Model> by lazy {
-        loadModelsFromAllowlist()
+    private val _models = mutableStateListOf<Model>()
+    val models: SnapshotStateList<Model> get() = _models
+
+    init {
+        _models.addAll(loadModels())
     }
 
-    private fun loadModelsFromAllowlist(): List<Model> {
+    /**
+     * Loads models from the bundled allowlist and any pre-existing local
+     * `.task` files the user may have added.
+     */
+    private fun loadModels(): List<Model> {
         val modelList = mutableListOf<Model>()
-        val jsonString = context.resources.openRawResource(R.raw.model_allowlist).bufferedReader().use { it.readText() }
+        val jsonString =
+            context.resources.openRawResource(R.raw.model_allowlist).bufferedReader().use { it.readText() }
         val json = JSONObject(jsonString)
         val keys = json.keys()
         while (keys.hasNext()) {
@@ -24,27 +43,57 @@ class ModelManager(private val context: Context) {
                 description = modelJson.getString("description"),
                 repo = modelJson.getString("repo"),
                 downloadUrl = modelJson.getString("downloadUrl"),
-                gated = modelJson.optBoolean("gated", false)
+                gated = modelJson.optBoolean("gated", false),
             )
-            val modelDir = java.io.File(context.filesDir, "models")
-            val modelFile = java.io.File(modelDir, "${model.id}.task")
-            val partialFile = java.io.File(modelDir, "${model.id}.task.part")
+            val modelDir = File(context.filesDir, "models")
+            val modelFile = File(modelDir, "${model.id}.task")
+            val partialFile = File(modelDir, "${model.id}.task.part")
             model.isDownloaded = modelFile.exists()
             model.hasPartial = !model.isDownloaded && partialFile.exists()
             modelList.add(model)
         }
+
+        // Include any additional models already placed in the models directory
+        val modelDir = File(context.filesDir, "models")
+        modelDir.listFiles { _, name -> name.endsWith(".task") }?.forEach { file ->
+            val id = file.nameWithoutExtension
+            if (modelList.none { it.id == id }) {
+                modelList.add(
+                    Model(
+                        id = id,
+                        name = id,
+                        description = "Local model",
+                        repo = "",
+                        downloadUrl = "",
+                        gated = false,
+                        isDownloaded = true,
+                    )
+                )
+            }
+        }
+
         return modelList
     }
 
+    /** Add a model supplied by the user at runtime. */
+    fun addLocalModel(model: Model) {
+        _models.add(model)
+    }
+
     fun getModel(id: String): Model? {
-        return models.find { it.id == id }
+        return _models.find { it.id == id }
     }
 
     fun deleteModel(model: Model) {
-        val modelDir = java.io.File(context.filesDir, "models")
-        java.io.File(modelDir, "${model.id}.task").delete()
-        java.io.File(modelDir, "${model.id}.task.part").delete()
-        model.isDownloaded = false
-        model.hasPartial = false
+        val modelDir = File(context.filesDir, "models")
+        File(modelDir, "${model.id}.task").delete()
+        File(modelDir, "${model.id}.task.part").delete()
+        if (model.repo.isEmpty() && model.downloadUrl.isEmpty()) {
+            _models.remove(model)
+        } else {
+            model.isDownloaded = false
+            model.hasPartial = false
+        }
     }
 }
+

--- a/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/ModelsScreen.kt
@@ -1,5 +1,8 @@
 package com.example.kokoro82m.screens
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -37,11 +40,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
+import androidx.documentfile.provider.DocumentFile
 import com.example.kokoro82m.data.Model
 import com.example.kokoro82m.data.ModelDownloader
 import com.example.kokoro82m.data.ModelManager
 import com.example.kokoro82m.data.UserPreferencesRepository
 import com.example.kokoro82m.utils.DebugLogger
+import java.io.File
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -57,6 +62,37 @@ fun ModelsScreen(userPreferencesRepository: UserPreferencesRepository) {
     var showDialog by remember { mutableStateOf(false) }
     var selectedModel by remember { mutableStateOf<Model?>(null) }
     var hfToken by remember { mutableStateOf("") }
+
+    val importLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri: Uri? ->
+        uri?.let {
+            val document = DocumentFile.fromSingleUri(context, it)
+            val name = document?.name ?: return@let
+            if (name.endsWith(".task")) {
+                val modelDir = File(context.filesDir, "models").apply { if (!exists()) mkdirs() }
+                context.contentResolver.openInputStream(it)?.use { inputStream ->
+                    File(modelDir, name).outputStream().use { output ->
+                        inputStream.copyTo(output)
+                    }
+                }
+                val id = name.removeSuffix(".task")
+                val model = Model(
+                    id = id,
+                    name = id,
+                    description = "Local model",
+                    repo = "",
+                    downloadUrl = "",
+                    gated = false,
+                    isDownloaded = true
+                )
+                modelManager.addLocalModel(model)
+                DebugLogger.log("ModelsScreen: Imported $name")
+            } else {
+                DebugLogger.log("ModelsScreen: Selected file is not a .task file")
+            }
+        }
+    }
 
     LaunchedEffect(Unit) {
         userPreferencesRepository.hfToken.collect { token ->
@@ -113,6 +149,12 @@ fun ModelsScreen(userPreferencesRepository: UserPreferencesRepository) {
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
+            item {
+                Button(onClick = { importLauncher.launch(arrayOf("*/*")) }) {
+                    Text("Import Local Model")
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
             items(models) { model ->
                 Column(modifier = Modifier.fillMaxWidth()) {
                     Text(text = model.name, style = MaterialTheme.typography.titleMedium)


### PR DESCRIPTION
## Summary
- allow importing local `.task` LLM files from the models screen
- load user-supplied models and existing `.task` files in ModelManager
- include DocumentFile dependency for file selection

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bf440afe08331bc5e5f4427bf8bb7