### PR TITLE
Expose LLM inference settings

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
@@ -9,14 +9,12 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.example.kokoro.chat.LlmInference
 import com.example.kokoro82m.data.ModelManager
 import com.example.kokoro82m.data.Model
 import com.example.kokoro82m.screens.ChatTtsScreen
 import com.example.kokoro82m.utils.OnnxRuntimeManager
 import com.example.kokoro82m.utils.DebugLogger
 import com.example.kokoro82m.viewmodel.ChatTtsViewModel
-import java.io.File
 
 class ChatTtsActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -63,15 +61,12 @@ class ChatTtsActivity : ComponentActivity() {
     }
 
     private fun startChat(model: Model, session: ai.onnxruntime.OrtSession) {
-        val modelFile = File(filesDir, "models/${model.id}.task")
-        val llmInference = LlmInference(applicationContext, modelFile.absolutePath)
-
         val viewModel: ChatTtsViewModel by viewModels {
             object : ViewModelProvider.Factory {
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {
                     if (modelClass.isAssignableFrom(ChatTtsViewModel::class.java)) {
                         @Suppress("UNCHECKED_CAST")
-                        return ChatTtsViewModel(applicationContext, session, llmInference) as T
+                        return ChatTtsViewModel(applicationContext, session, model) as T
                     }
                     throw IllegalArgumentException("Unknown ViewModel class")
                 }

--- a/app/src/main/java/com/example/kokoro82m/data/Model.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/Model.kt
@@ -9,4 +9,32 @@ data class Model(
     val gated: Boolean,
     var isDownloaded: Boolean = false,
     var hasPartial: Boolean = false,
-)
+    val maxTokens: Int? = null,
+    val topK: Int? = null,
+    val topP: Float? = null,
+    val temperature: Float? = null,
+) {
+    fun getIntConfigValue(key: String, defaultValue: Int): Int = when (key) {
+        ConfigKeys.MAX_TOKENS -> maxTokens ?: defaultValue
+        ConfigKeys.TOPK -> topK ?: defaultValue
+        else -> defaultValue
+    }
+
+    fun getFloatConfigValue(key: String, defaultValue: Float): Float = when (key) {
+        ConfigKeys.TOPP -> topP ?: defaultValue
+        ConfigKeys.TEMPERATURE -> temperature ?: defaultValue
+        else -> defaultValue
+    }
+}
+
+object ConfigKeys {
+    const val MAX_TOKENS = "maxTokens"
+    const val TOPK = "topK"
+    const val TOPP = "topP"
+    const val TEMPERATURE = "temperature"
+}
+
+const val DEFAULT_MAX_TOKEN = 4096
+const val DEFAULT_TOPK = 40
+const val DEFAULT_TOPP = 0.95f
+const val DEFAULT_TEMPERATURE = 0.8f

--- a/app/src/main/java/com/example/kokoro82m/data/ModelManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/data/ModelManager.kt
@@ -44,6 +44,10 @@ class ModelManager(private val context: Context) {
                 repo = modelJson.getString("repo"),
                 downloadUrl = modelJson.getString("downloadUrl"),
                 gated = modelJson.optBoolean("gated", false),
+                maxTokens = if (modelJson.has(ConfigKeys.MAX_TOKENS)) modelJson.getInt(ConfigKeys.MAX_TOKENS) else null,
+                topK = if (modelJson.has(ConfigKeys.TOPK)) modelJson.getInt(ConfigKeys.TOPK) else null,
+                topP = if (modelJson.has(ConfigKeys.TOPP)) modelJson.getDouble(ConfigKeys.TOPP).toFloat() else null,
+                temperature = if (modelJson.has(ConfigKeys.TEMPERATURE)) modelJson.getDouble(ConfigKeys.TEMPERATURE).toFloat() else null,
             )
             val modelDir = File(context.filesDir, "models")
             val modelFile = File(modelDir, "${model.id}.task")

--- a/app/src/main/java/com/example/kokoro82m/llm/LlmChatModelHelper.kt
+++ b/app/src/main/java/com/example/kokoro82m/llm/LlmChatModelHelper.kt
@@ -1,0 +1,46 @@
+package com.example.kokoro82m.llm
+
+import android.content.Context
+import com.example.kokoro82m.data.*
+import com.google.mediapipe.tasks.genai.llminference.LlmInference
+import java.io.File
+
+/**
+ * Helper to create [LlmInference] instances with configurable generation
+ * parameters. Defaults are read from the model allowlist but callers may
+ * override them by providing an [InferenceOptions] instance.
+ */
+object LlmChatModelHelper {
+
+    data class InferenceOptions(
+        val maxTokens: Int? = null,
+        val topK: Int? = null,
+        val topP: Float? = null,
+        val temperature: Float? = null,
+    )
+
+    fun initialize(
+        context: Context,
+        model: Model,
+        options: InferenceOptions = InferenceOptions()
+    ): LlmInference {
+        val maxTokens = options.maxTokens
+            ?: model.getIntConfigValue(ConfigKeys.MAX_TOKENS, DEFAULT_MAX_TOKEN)
+        val topK = options.topK
+            ?: model.getIntConfigValue(ConfigKeys.TOPK, DEFAULT_TOPK)
+        val topP = options.topP
+            ?: model.getFloatConfigValue(ConfigKeys.TOPP, DEFAULT_TOPP)
+        val temperature = options.temperature
+            ?: model.getFloatConfigValue(ConfigKeys.TEMPERATURE, DEFAULT_TEMPERATURE)
+
+        val builder = LlmInference.LlmInferenceOptions.builder()
+            .setModelPath(File(context.filesDir, "models/${model.id}.task").absolutePath)
+            .setMaxTokens(maxTokens)
+            .setTopK(topK)
+            .setTopP(topP)
+            .setTemperature(temperature)
+
+        return LlmInference.createFromOptions(context, builder.build())
+    }
+}
+

--- a/app/src/main/java/com/example/kokoro82m/llm/LlmChatModelHelper.kt
+++ b/app/src/main/java/com/example/kokoro82m/llm/LlmChatModelHelper.kt
@@ -3,10 +3,11 @@ package com.example.kokoro82m.llm
 import android.content.Context
 import com.example.kokoro82m.data.*
 import com.google.mediapipe.tasks.genai.llminference.LlmInference
+import com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession
 import java.io.File
 
 /**
- * Helper to create [LlmInference] instances with configurable generation
+ * Helper to create [LlmInferenceSession] instances with configurable generation
  * parameters. Defaults are read from the model allowlist but callers may
  * override them by providing an [InferenceOptions] instance.
  */
@@ -22,8 +23,8 @@ object LlmChatModelHelper {
     fun initialize(
         context: Context,
         model: Model,
-        options: InferenceOptions = InferenceOptions()
-    ): LlmInference {
+        options: InferenceOptions = InferenceOptions(),
+    ): LlmInferenceSession {
         val maxTokens = options.maxTokens
             ?: model.getIntConfigValue(ConfigKeys.MAX_TOKENS, DEFAULT_MAX_TOKEN)
         val topK = options.topK
@@ -33,14 +34,20 @@ object LlmChatModelHelper {
         val temperature = options.temperature
             ?: model.getFloatConfigValue(ConfigKeys.TEMPERATURE, DEFAULT_TEMPERATURE)
 
-        val builder = LlmInference.LlmInferenceOptions.builder()
+        val inferenceOptions = LlmInference.LlmInferenceOptions.builder()
             .setModelPath(File(context.filesDir, "models/${model.id}.task").absolutePath)
             .setMaxTokens(maxTokens)
+            .setMaxTopK(topK)
+            .build()
+
+        val llm = LlmInference.createFromOptions(context, inferenceOptions)
+
+        val sessionOptions = LlmInferenceSession.LlmInferenceSessionOptions.builder()
             .setTopK(topK)
             .setTopP(topP)
             .setTemperature(temperature)
+            .build()
 
-        return LlmInference.createFromOptions(context, builder.build())
+        return LlmInferenceSession.createFromOptions(llm, sessionOptions)
     }
 }
-

--- a/app/src/main/java/com/example/kokoro82m/screens/ChatTtsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/ChatTtsScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.example.kokoro.chat.MessageBubble

--- a/app/src/main/java/com/example/kokoro82m/screens/ChatTtsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/ChatTtsScreen.kt
@@ -39,6 +39,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.example.kokoro.chat.MessageBubble
 import com.example.kokoro82m.utils.PlayerState
@@ -60,6 +62,11 @@ fun ChatTtsScreen(
     val weights by viewModel.weights.collectAsState()
     val interpolationMode by viewModel.interpolationMode.collectAsState()
     val speed by viewModel.speed.collectAsState()
+
+    val maxTokens by viewModel.maxTokens.collectAsState()
+    val topK by viewModel.topK.collectAsState()
+    val topP by viewModel.topP.collectAsState()
+    val temperature by viewModel.temperature.collectAsState()
 
     var message by remember { mutableStateOf("") }
     val listState = rememberLazyListState()
@@ -87,6 +94,61 @@ fun ChatTtsScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
+            // LLM Settings
+            var maxTokensText by remember(maxTokens) { mutableStateOf(maxTokens.toString()) }
+            var topKText by remember(topK) { mutableStateOf(topK.toString()) }
+            var topPText by remember(topP) { mutableStateOf(topP.toString()) }
+            var temperatureText by remember(temperature) { mutableStateOf(temperature.toString()) }
+
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("LLM Settings", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = maxTokensText,
+                        onValueChange = { maxTokensText = it },
+                        label = { Text("Max Tokens") },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = topKText,
+                        onValueChange = { topKText = it },
+                        label = { Text("Top K") },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = topPText,
+                        onValueChange = { topPText = it },
+                        label = { Text("Top P") },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal)
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = temperatureText,
+                        onValueChange = { temperatureText = it },
+                        label = { Text("Temperature") },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal)
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Button(onClick = {
+                        viewModel.updateInferenceSettings(
+                            maxTokensText.toIntOrNull() ?: maxTokens,
+                            topKText.toIntOrNull() ?: topK,
+                            topPText.toFloatOrNull() ?: topP,
+                            temperatureText.toFloatOrNull() ?: temperature,
+                        )
+                    }) {
+                        Text("Apply")
+                    }
+                }
+            }
+
             // Mixer Settings in a Card
             Card(
                 modifier = Modifier

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
@@ -5,7 +5,16 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ai.onnxruntime.OrtSession
 import com.example.kokoro.chat.ChatMessage
-import com.example.kokoro.chat.LlmInference
+import com.example.kokoro82m.data.ConfigKeys
+import com.example.kokoro82m.data.DEFAULT_MAX_TOKEN
+import com.example.kokoro82m.data.DEFAULT_TOPK
+import com.example.kokoro82m.data.DEFAULT_TOPP
+import com.example.kokoro82m.data.DEFAULT_TEMPERATURE
+import com.example.kokoro82m.data.Model
+import com.example.kokoro82m.data.getFloatConfigValue
+import com.example.kokoro82m.data.getIntConfigValue
+import com.example.kokoro82m.llm.LlmChatModelHelper
+import com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession
 import com.example.kokoro82m.utils.AudioPlayer
 import com.example.kokoro82m.utils.InterpolationMode
 import com.example.kokoro82m.utils.KittenAudioPlayer
@@ -31,7 +40,7 @@ import java.lang.StringBuilder
 class ChatTtsViewModel(
     private val context: Context,
     private val ortSession: OrtSession,
-    private val llmInference: LlmInference
+    private val model: Model,
 ) : ViewModel() {
 
     // Dependencies
@@ -74,10 +83,25 @@ class ChatTtsViewModel(
     private val _speed = MutableStateFlow(1.0f)
     val speed = _speed.asStateFlow()
 
+    // LLM Settings
+    private val _maxTokens = MutableStateFlow(model.getIntConfigValue(ConfigKeys.MAX_TOKENS, DEFAULT_MAX_TOKEN))
+    val maxTokens = _maxTokens.asStateFlow()
+
+    private val _topK = MutableStateFlow(model.getIntConfigValue(ConfigKeys.TOPK, DEFAULT_TOPK))
+    val topK = _topK.asStateFlow()
+
+    private val _topP = MutableStateFlow(model.getFloatConfigValue(ConfigKeys.TOPP, DEFAULT_TOPP))
+    val topP = _topP.asStateFlow()
+
+    private val _temperature = MutableStateFlow(model.getFloatConfigValue(ConfigKeys.TEMPERATURE, DEFAULT_TEMPERATURE))
+    val temperature = _temperature.asStateFlow()
+
+    private var llmSession: LlmInferenceSession? = null
+
     private val audioQueue = Channel<FloatArray>(Channel.UNLIMITED)
 
     init {
-        llmInference.initialize()
+        rebuildLlmSession()
         // Launch a coroutine to play queued audio sequentially
         viewModelScope.launch {
             for (audio in audioQueue) {
@@ -101,7 +125,7 @@ class ChatTtsViewModel(
         _chatMessages.value += ChatMessage("...", false)  // placeholder
 
         viewModelScope.launch(Dispatchers.IO) {
-            llmInference.sendMessage(message) { partial, done ->
+            llmSession?.generateResponseAsync(message) { partial, done ->
                 if (!done) {
                     responseBuilder.append(partial)
                     sentenceBuilder.append(partial)
@@ -118,6 +142,28 @@ class ChatTtsViewModel(
                 }
             }
         }
+    }
+
+    private fun rebuildLlmSession() {
+        llmSession?.close()
+        llmSession = LlmChatModelHelper.initialize(
+            context,
+            model,
+            LlmChatModelHelper.InferenceOptions(
+                maxTokens = _maxTokens.value,
+                topK = _topK.value,
+                topP = _topP.value,
+                temperature = _temperature.value,
+            ),
+        )
+    }
+
+    fun updateInferenceSettings(maxTokens: Int, topK: Int, topP: Float, temperature: Float) {
+        _maxTokens.value = maxTokens
+        _topK.value = topK
+        _topP.value = topP
+        _temperature.value = temperature
+        rebuildLlmSession()
     }
 
     private fun processSentences(builder: StringBuilder, done: Boolean) {
@@ -213,7 +259,7 @@ class ChatTtsViewModel(
 
     override fun onCleared() {
         super.onCleared()
-        llmInference.close()
+        llmSession?.close()
         audioPlayer.stop()
     }
 }

--- a/app/src/main/res/raw/model_allowlist.json
+++ b/app/src/main/res/raw/model_allowlist.json
@@ -4,27 +4,43 @@
     "description": "Preview version of Gemma 3n E2B ready for deployment on Android",
     "repo": "google/gemma-3n-E2B-it-litert-preview",
     "downloadUrl": "https://huggingface.co/google/gemma-3n-E2B-it-litert-preview/resolve/main/gemma-3n-E2B-it-int4.task",
-    "gated": true
+    "gated": true,
+    "maxTokens": 4096,
+    "topK": 40,
+    "topP": 0.95,
+    "temperature": 0.8
   },
   "gemma-3n-E4B-it-int4": {
     "name": "Gemma 3n IT 4B",
     "description": "Gemma 3n Instruct 4B parameter model",
     "repo": "google/gemma-3n-E4B-it-int4",
     "downloadUrl": "https://huggingface.co/google/gemma-3n-E4B-it-litert-preview/resolve/main/gemma-3n-E4B-it-int4.task",
-    "gated": true
+    "gated": true,
+    "maxTokens": 4096,
+    "topK": 40,
+    "topP": 0.95,
+    "temperature": 0.8
   },
   "gemma3-1b-it-q4": {
     "name": "Gemma3 1B IT q4",
     "description": "A 4-bit variant of Gemma3 1B IT for Android",
     "repo": "litert-community/Gemma3-1B-IT",
     "downloadUrl": "https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/Gemma3-1B-IT_multi-prefill-seq_q4_ekv2048.task",
-    "gated": false
+    "gated": false,
+    "maxTokens": 4096,
+    "topK": 40,
+    "topP": 0.95,
+    "temperature": 0.8
   },
   "qwen2.5-1.5b-instruct-q8": {
     "name": "Qwen2.5 1.5B Instruct q8",
     "description": "A quantized 8-bit Qwen2.5 1.5B Instruct model",
     "repo": "litert-community/Qwen2.5-1.5B-Instruct",
     "downloadUrl": "https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct/resolve/main/Qwen2.5-1.5B-Instruct_multi-prefill-seq_q8_ekv1280.task",
-    "gated": false
+    "gated": false,
+    "maxTokens": 4096,
+    "topK": 40,
+    "topP": 0.95,
+    "temperature": 0.8
   }
 }


### PR DESCRIPTION
## Summary
- allow models to specify default max tokens, sampling options, and temperature
- parse new defaults from model allowlist json
- add LlmChatModelHelper to override or use defaults when creating LLM inference

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cc71b32808331865571ed15fc6bc6