### PR TITLE
Handle Markdown output in chat and enlarge message input

### DIFF
--- a/app-chat/build.gradle.kts
+++ b/app-chat/build.gradle.kts
@@ -54,4 +54,5 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+    implementation("com.github.jeziellago:compose-markdown:0.4.1")
 }

--- a/app-chat/src/main/java/com/example/kokoro/chat/ChatScreen.kt
+++ b/app-chat/src/main/java/com/example/kokoro/chat/ChatScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -27,6 +28,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import dev.jeziellago.compose.markdowntext.MarkdownText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -97,9 +99,13 @@ fun ChatScreen(
                 OutlinedTextField(
                     value = message,
                     onValueChange = { message = it },
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier
+                        .weight(1f)
+                        .heightIn(min = 80.dp),
                     label = { Text("Message") },
-                    shape = RoundedCornerShape(24.dp)
+                    shape = RoundedCornerShape(24.dp),
+                    maxLines = 5,
+                    minLines = 3
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(
@@ -136,8 +142,11 @@ fun MessageBubble(chatMessage: ChatMessage) {
                 containerColor = if (chatMessage.isFromUser) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.secondaryContainer
             )
         ) {
-            Text(
-                text = chatMessage.message,
+            val formatted = chatMessage.message
+                .replace("\\n", "\n")
+                .replace("/n", "\n")
+            MarkdownText(
+                markdown = formatted,
                 modifier = Modifier.padding(12.dp)
             )
         }

--- a/app-chat/src/main/java/com/example/kokoro/chat/ChatScreen.kt
+++ b/app-chat/src/main/java/com/example/kokoro/chat/ChatScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -104,6 +105,10 @@ fun ChatScreen(
                         .heightIn(min = 80.dp),
                     label = { Text("Message") },
                     shape = RoundedCornerShape(24.dp),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant
+                    ),
                     maxLines = 5,
                     minLines = 3
                 )

--- a/app/src/main/java/com/example/kokoro82m/screens/ChatTtsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/ChatTtsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold

--- a/app/src/main/java/com/example/kokoro82m/screens/ChatTtsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/ChatTtsScreen.kt
@@ -15,9 +15,12 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -26,6 +29,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -63,6 +67,7 @@ fun ChatTtsScreen(
 
     var message by remember { mutableStateOf("") }
     val listState = rememberLazyListState()
+    var showMixerSettings by remember { mutableStateOf(false) }
 
     LaunchedEffect(chatMessages.size) {
         if (chatMessages.isNotEmpty()) {
@@ -87,44 +92,60 @@ fun ChatTtsScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
+
             // Mixer Settings in a Card
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(8.dp)
+                    .padding(8.dp),
             ) {
-                Column(
-                    modifier = Modifier
-                        .padding(16.dp)
-                        .verticalScroll(rememberScrollState())
-                ) {
-                    Text("Voice Mixer Settings", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
-                    Spacer(modifier = Modifier.height(8.dp))
-                    StyleSelector(
-                        styleNames = viewModel.styleLoader.names,
-                        selectedStyles = selectedStyles,
-                        onAddStyle = viewModel::addStyle,
-                        onRemoveStyle = viewModel::removeStyle
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    WeightSliders(
-                        selectedStyles = selectedStyles,
-                        weights = weights,
-                        onWeightChanged = viewModel::updateWeight
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    InterpolationModeSelector(
-                        currentMode = interpolationMode,
-                        onModeSelected = viewModel::updateInterpolationMode
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text("Speed: ${"%.2f".format(speed)}")
-                    Slider(
-                        value = speed,
-                        onValueChange = { viewModel.updateSpeed(it) },
-                        valueRange = 0.5f..2.0f,
-                        steps = 15
-                    )
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { showMixerSettings = !showMixerSettings },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            "Voice Mixer Settings",
+                            style = androidx.compose.material3.MaterialTheme.typography.titleMedium,
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        Icon(
+                            imageVector = if (showMixerSettings) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                            contentDescription = if (showMixerSettings) "Collapse" else "Expand",
+                        )
+                    }
+                    if (showMixerSettings) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                            StyleSelector(
+                                styleNames = viewModel.styleLoader.names,
+                                selectedStyles = selectedStyles,
+                                onAddStyle = viewModel::addStyle,
+                                onRemoveStyle = viewModel::removeStyle,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            WeightSliders(
+                                selectedStyles = selectedStyles,
+                                weights = weights,
+                                onWeightChanged = viewModel::updateWeight,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            InterpolationModeSelector(
+                                currentMode = interpolationMode,
+                                onModeSelected = viewModel::updateInterpolationMode,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text("Speed: ${"%.2f".format(speed)}")
+                            Slider(
+                                value = speed,
+                                onValueChange = { viewModel.updateSpeed(it) },
+                                valueRange = 0.5f..2.0f,
+                                steps = 15,
+                            )
+                        }
+                    }
                 }
             }
 
@@ -184,7 +205,11 @@ fun ChatTtsScreen(
                     onValueChange = { message = it },
                     modifier = Modifier.weight(1f),
                     label = { Text("Message") },
-                    shape = RoundedCornerShape(24.dp)
+                    shape = RoundedCornerShape(24.dp),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant
+                    )
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(


### PR DESCRIPTION
## Summary
- render markdown responses and convert `\n` and `/n` to real line breaks
- expand chat message input field for easier multi-line typing
- add compose-markdown dependency

## Testing
- `gradle :app-chat:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cdd5d1fa88331b793772536a25c47