### PR TITLE
Handle orientation without activity recreation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
             android:exported="true"
             android:theme="@style/AppTheme.Splash"
             android:forceDarkAllowed="true"
-            android:configChanges="uiMode">
+            android:configChanges="orientation|screenSize|uiMode">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -39,7 +39,7 @@
             android:exported="true"
             android:theme="@style/AppTheme"
             android:forceDarkAllowed="true"
-            android:configChanges="uiMode">
+            android:configChanges="orientation|screenSize|uiMode">
         </activity>
 
         <receiver


### PR DESCRIPTION
## Summary
- prevent MainActivity and ChatTtsActivity from restarting on orientation changes by handling orientation and screen size config changes

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d49f8bc9c83319d0954a3d604d188