### PR TITLE
Add benchmark mode with PerfHud and PerfKit

### DIFF
--- a/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/ChatTtsActivity.kt
@@ -15,6 +15,8 @@ import com.example.kokoro82m.data.Model
 import com.example.kokoro82m.screens.ChatTtsScreen
 import com.example.kokoro82m.utils.OnnxRuntimeManager
 import com.example.kokoro82m.utils.DebugLogger
+import com.example.kokoro82m.utils.SettingsManager
+import com.example.kokoro.galleryport.PerfHud
 import com.example.kokoro82m.viewmodel.ChatTtsViewModel
 import java.io.File
 
@@ -81,6 +83,9 @@ class ChatTtsActivity : ComponentActivity() {
         setContent {
             NabuTheme {
                 ChatTtsScreen(viewModel = viewModel, modelName = model.name, onBackPressed = { finish() })
+                if (SettingsManager.isBenchmark(this@ChatTtsActivity)) {
+                    PerfHud.Overlay()
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/kokoro82m/MainActivity.kt
+++ b/app/src/main/java/com/example/kokoro82m/MainActivity.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.os.SystemClock
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.ComponentActivity
@@ -76,6 +77,7 @@ import com.example.kokoro82m.utils.PhonemeConverter
 import com.example.kokoro82m.utils.StyleLoader
 import com.example.kokoro82m.utils.createAudio
 import com.example.kokoro82m.utils.createKittenAudioFromStyleVector
+import com.example.kokoro82m.utils.BenchmarkManager
 import com.example.kokoro82m.utils.KittenPhonemizer
 import com.example.kokoro82m.utils.playAudio
 import com.example.kokoro82m.utils.saveAudio
@@ -180,6 +182,10 @@ class MainActivity : ComponentActivity() {
                     userPreferencesRepository = userPreferencesRepository,
                     initialScreen = startScreen
                 )
+
+                if (SettingsManager.isBenchmark(this@MainActivity)) {
+                    PerfHud.Overlay()
+                }
             }
         }
 
@@ -217,6 +223,7 @@ private fun generateAudio(
     scope.launch(Dispatchers.IO) {
         try {
             val engine = SettingsManager.getTtsEngine(context)
+            val ttsStart = SystemClock.elapsedRealtime()
             val (audioData, sampleRate) = if (engine == TtsEngine.KITTEN) {
                 val (phonemeStr, tokens) = KittenPhonemizer.phonemize(text)
                 DebugLogger.log("Phonemes: $phonemeStr")
@@ -248,6 +255,12 @@ private fun generateAudio(
                         session = session
                     )
                 }
+            }
+            val genMs = SystemClock.elapsedRealtime() - ttsStart
+            if (SettingsManager.isBenchmark(context)) {
+                val audioMs = audioData.size * 1000L / sampleRate
+                BenchmarkManager.recordTts(engine, genMs, audioMs)
+                BenchmarkManager.profileSystem(context)
             }
 
             playAudio(

--- a/app/src/main/java/com/example/kokoro82m/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/kokoro82m/screens/SettingsScreen.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.withContext
 fun SettingsScreen() {
     val context = LocalContext.current
     var debug by remember { mutableStateOf(SettingsManager.isDebug(context)) }
+    var benchmark by remember { mutableStateOf(SettingsManager.isBenchmark(context)) }
     var engine by remember { mutableStateOf(SettingsManager.getTtsEngine(context)) }
     var expanded by remember { mutableStateOf(false) }
 
@@ -52,6 +53,17 @@ fun SettingsScreen() {
                 }
             )
             Text(text = "Debug Mode", modifier = Modifier.padding(start = 8.dp))
+        }
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Switch(
+                checked = benchmark,
+                onCheckedChange = {
+                    benchmark = it
+                    SettingsManager.setBenchmark(context, it)
+                }
+            )
+            Text(text = "Benchmark Mode", modifier = Modifier.padding(start = 8.dp))
         }
 
         ExposedDropdownMenuBox(

--- a/app/src/main/java/com/example/kokoro82m/utils/BenchmarkManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/BenchmarkManager.kt
@@ -1,0 +1,60 @@
+package com.example.kokoro82m.utils
+
+import android.content.Context
+import android.os.SystemClock
+
+/**
+ * Collects benchmarking information for LLM and TTS operations.
+ * When enabled via [SettingsManager.isBenchmark], metrics are logged
+ * through [DebugLogger] so they can be inspected or saved to file.
+ */
+object BenchmarkManager {
+    private var llmStart: Long = 0L
+    private var firstToken: Long = 0L
+    private var tokenCount: Int = 0
+    private var lastToken: Long = 0L
+
+    fun startLlm() {
+        llmStart = SystemClock.elapsedRealtime()
+        firstToken = 0L
+        tokenCount = 0
+        lastToken = llmStart
+    }
+
+    fun recordPartial(text: String) {
+        val now = SystemClock.elapsedRealtime()
+        if (tokenCount == 0) {
+            firstToken = now
+            DebugLogger.log("LLM time to first token: ${firstToken - llmStart} ms")
+        }
+        tokenCount += text.trim().split(Regex("\\s+")).size
+        val elapsed = now - llmStart
+        val tps = tokenCount * 1000f / elapsed.coerceAtLeast(1)
+        DebugLogger.log("LLM tokens per second: ${"%.2f".format(tps)}")
+        lastToken = now
+    }
+
+    fun finishLlm() {
+        val now = SystemClock.elapsedRealtime()
+        val elapsed = now - llmStart
+        DebugLogger.log("LLM total tokens: $tokenCount in $elapsed ms")
+        lastToken = now
+    }
+
+    fun handoff() {
+        val now = SystemClock.elapsedRealtime()
+        DebugLogger.log("LLM->TTS handoff delay: ${now - lastToken} ms")
+    }
+
+    fun recordTts(engine: TtsEngine, genTimeMs: Long, audioDurationMs: Long) {
+        val ratio = if (genTimeMs > 0) audioDurationMs.toFloat() / genTimeMs else 0f
+        DebugLogger.log(
+            "TTS ${engine.name} gen ${genTimeMs}ms for ${audioDurationMs}ms audio (x${"%.2f".format(ratio)})"
+        )
+    }
+
+    fun profileSystem(context: Context) {
+        PerfKit.profile(context)
+    }
+}
+

--- a/app/src/main/java/com/example/kokoro82m/utils/PerfKit.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/PerfKit.kt
@@ -1,0 +1,17 @@
+package com.example.kokoro82m.utils
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Debug
+
+/** Simple wrapper to collect basic CPU and memory stats. */
+object PerfKit {
+    fun profile(context: Context) {
+        val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val memInfo = ActivityManager.MemoryInfo()
+        am.getMemoryInfo(memInfo)
+        val cpuMs = Debug.threadCpuTimeNanos() / 1_000_000
+        DebugLogger.log("PerfKit CPU ${cpuMs}ms availMem ${memInfo.availMem}")
+    }
+}
+

--- a/app/src/main/java/com/example/kokoro82m/utils/SettingsManager.kt
+++ b/app/src/main/java/com/example/kokoro82m/utils/SettingsManager.kt
@@ -10,6 +10,13 @@ object SettingsManager {
     fun isDebug(context: Context): Boolean =
         (DatabaseManager.getSetting(context, "debug") ?: "0") == "1"
 
+    fun setBenchmark(context: Context, enabled: Boolean) {
+        DatabaseManager.setSetting(context, "benchmark", if (enabled) "1" else "0")
+    }
+
+    fun isBenchmark(context: Context): Boolean =
+        (DatabaseManager.getSetting(context, "benchmark") ?: "0") == "1"
+
     fun setStyle(context: Context, style: String) {
         DatabaseManager.setSetting(context, "style", style)
     }

--- a/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
+++ b/app/src/main/java/com/example/kokoro82m/viewmodel/ChatTtsViewModel.kt
@@ -20,6 +20,8 @@ import com.example.kokoro82m.utils.createKittenAudioFromStyleVector
 import com.example.kokoro82m.utils.SettingsManager
 import com.example.kokoro82m.utils.TtsEngine
 import com.example.kokoro82m.utils.mixStyles
+import com.example.kokoro82m.utils.BenchmarkManager
+import android.os.SystemClock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -96,12 +98,25 @@ class ChatTtsViewModel(
         _chatMessages.value += ChatMessage(message, true)
         _isLoading.value = true
 
+        val benchmarkEnabled = SettingsManager.isBenchmark(context)
+        if (benchmarkEnabled) {
+            BenchmarkManager.startLlm()
+        }
+
         val responseBuilder = StringBuilder()
         val sentenceBuilder = StringBuilder()
         _chatMessages.value += ChatMessage("...", false)  // placeholder
 
         viewModelScope.launch(Dispatchers.IO) {
             llmInference.sendMessage(message) { partial, done ->
+                if (benchmarkEnabled) {
+                    if (!done) {
+                        BenchmarkManager.recordPartial(partial)
+                    } else {
+                        BenchmarkManager.finishLlm()
+                        BenchmarkManager.profileSystem(context)
+                    }
+                }
                 if (!done) {
                     responseBuilder.append(partial)
                     sentenceBuilder.append(partial)
@@ -146,6 +161,10 @@ class ChatTtsViewModel(
         viewModelScope.launch {
             _isSynthesizing.value = true
             try {
+                val benchmark = SettingsManager.isBenchmark(context)
+                if (benchmark) {
+                    BenchmarkManager.handoff()
+                }
                 DebugLogger.log("Synthesizing: ${text}")
                 val audioData = withContext(Dispatchers.IO) {
                     val mixedVector = mixStyles(
@@ -155,7 +174,8 @@ class ChatTtsViewModel(
                         _interpolationMode.value
                     )
                     val engine = SettingsManager.getTtsEngine(context)
-                    val (data, _) = if (engine == TtsEngine.KITTEN) {
+                    val ttsStart = SystemClock.elapsedRealtime()
+                    val (data, sampleRate) = if (engine == TtsEngine.KITTEN) {
                         val (_, tokens) = KittenPhonemizer.phonemize(text)
                         createKittenAudioFromStyleVector(
                             tokens = tokens,
@@ -171,6 +191,12 @@ class ChatTtsViewModel(
                             speed = _speed.value,
                             session = ortSession
                         )
+                    }
+                    val genMs = SystemClock.elapsedRealtime() - ttsStart
+                    if (benchmark) {
+                        val audioMs = data.size * 1000L / sampleRate
+                        BenchmarkManager.recordTts(engine, genMs, audioMs)
+                        BenchmarkManager.profileSystem(context)
                     }
                     data
                 }


### PR DESCRIPTION
## Summary
- add BenchmarkManager and PerfKit profiling utilities
- expose benchmark toggle in settings
- log LLM and TTS metrics with PerfHud overlay

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d4a5d52008331a8a8aed44ef299c2